### PR TITLE
Improvements to qmake debugging options

### DIFF
--- a/Builds/QtCreator/shared_settings.pri
+++ b/Builds/QtCreator/shared_settings.pri
@@ -35,6 +35,7 @@ native {
 
 
 DESTDIR = $$(HOME)/Dev/fractorium/Bin
+debug:DESTDIR = $$(HOME)/Dev/fractorium/Dbg
 
 LIBS += -L/usr/lib -ljpeg
 LIBS += -L/usr/lib -lpng

--- a/Builds/QtCreator/shared_settings.pri
+++ b/Builds/QtCreator/shared_settings.pri
@@ -54,10 +54,10 @@ INCLUDEPATH += ../../../Source/EmberCommon
 
 QMAKE_CXXFLAGS_RELEASE += -O2
 QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
+QMAKE_CXXFLAGS_RELEASE += -fomit-frame-pointer
 
 QMAKE_CXXFLAGS += -fPIC
 QMAKE_CXXFLAGS += -fpermissive
-QMAKE_CXXFLAGS += -fomit-frame-pointer
 QMAKE_CXXFLAGS += -pedantic
 QMAKE_CXXFLAGS += -std=c++11
 QMAKE_CXXFLAGS += -Wnon-virtual-dtor


### PR DESCRIPTION
Frame pointer is important for debugging, so move -fomit-frame-pointer to release-only flags
Also updated qmake settings to use a different output directory for debug builds