### PR TITLE
Fix opencl rendering issues on Os X

### DIFF
--- a/Source/Ember/Variations01.h
+++ b/Source/Ember/Variations01.h
@@ -202,7 +202,7 @@ public:
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(precalcSqrtSumSquares);\n"
 		   << "\n"
 		   << "\t\tvOut.x = (vIn.x - vIn.y) * (vIn.x + vIn.y) * r;\n"
-		   << "\t\tvOut.y = T(2.0) * vIn.x * vIn.y * r;\n"
+		   << "\t\tvOut.y = (real_t)(2.0) * vIn.x * vIn.y * r;\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -239,7 +239,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (precalcAtanxy * M_1_PI);\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (precalcSqrtSumSquares - T(1.0));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (precalcSqrtSumSquares - (real_t)(1.0));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -610,7 +610,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * sqrt(precalcSqrtSumSquares);\n"
-		   << "\t\treal_t a = T(0.5) * precalcAtanxy;\n"
+		   << "\t\treal_t a = (real_t)(0.5) * precalcAtanxy;\n"
 		   << "\n"
 		   << "\t\tif (MwcNext(mwc) & 1)\n"
 		   << "\t\t	a += M_PI;\n"
@@ -657,8 +657,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t nx = vIn.x < T(0.0) ? (vIn.x * T(2.0)) : vIn.x;\n"
-		   << "\t\treal_t ny = vIn.y < T(0.0) ? (vIn.y / T(2.0)) : vIn.y;\n"
+		   << "\t\treal_t nx = vIn.x < (real_t)(0.0) ? (vIn.x * (real_t)(2.0)) : vIn.x;\n"
+		   << "\t\treal_t ny = vIn.y < (real_t)(0.0) ? (vIn.y / (real_t)(2.0)) : vIn.y;\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * nx;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * ny;\n"
@@ -878,7 +878,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t dx = xform->m_VariationWeights[" << varIndex << "] * exp(vIn.x - T(1.0));\n"
+		   << "\t\treal_t dx = xform->m_VariationWeights[" << varIndex << "] * exp(vIn.x - (real_t)(1.0));\n"
 		   << "\t\treal_t dy = M_PI * vIn.y;\n"
 		   << "\n"
 		   << "\t\tvOut.x = dx * cos(dy);\n"
@@ -1074,7 +1074,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t dx = M_PI * Zeps(xform->m_C * xform->m_C);\n"
 		   << "\t\treal_t dy = xform->m_F;\n"
-		   << "\t\treal_t dx2 = T(0.5) * dx;\n"
+		   << "\t\treal_t dx2 = (real_t)(0.5) * dx;\n"
 		   << "\t\treal_t a = precalcAtanxy + ((fmod(precalcAtanxy + dy, dx) > dx2) ? -dx2 : dx2);\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * precalcSqrtSumSquares;\n"
 		   << "\n"
@@ -1130,7 +1130,7 @@ public:
 		string blobDiff  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * (T(0.5) + T(0.5) * sin(" << blobWaves << " * precalcAtanxy)));\n"
+		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * ((real_t)(0.5) + (real_t)(0.5) * sin(" << blobWaves << " * precalcAtanxy)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] * precalcSina * r);\n"
 		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] * precalcCosa * r);\n"
@@ -1408,7 +1408,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t r = precalcSqrtSumSquares;\n"
 		   << "\n"
-		   << "\t\tr += -T(2.0) * " << rings2Val2 << " * (int)((r + " << rings2Val2 << ") / (T(2.0) * " << rings2Val2 << ")) + r * (T(1.0) - " << rings2Val2 << ");\n"
+		   << "\t\tr += -(real_t)(2.0) * " << rings2Val2 << " * (int)((r + " << rings2Val2 << ") / ((real_t)(2.0) * " << rings2Val2 << ")) + r * ((real_t)(1.0) - " << rings2Val2 << ");\n"
 		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] * precalcSina * r);\n"
 		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] * precalcCosa * r);\n"
 		   << "\t\tvOut.z =  xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
@@ -1471,7 +1471,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = (xform->m_VariationWeights[" << varIndex << "] * T(2.0)) / (precalcSqrtSumSquares + T(1.0));\n"
+		   << "\t\treal_t r = (xform->m_VariationWeights[" << varIndex << "] * (real_t)(2.0)) / (precalcSqrtSumSquares + (real_t)(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
 		   << "\t\tvOut.y = r * vIn.y;\n"
@@ -1509,7 +1509,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t denom = T(0.25) * precalcSumSquares + 1;\n"
+		   << "\t\treal_t denom = (real_t)(0.25) * precalcSumSquares + 1;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / denom;\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
@@ -1591,7 +1591,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t d = Zeps(" << dist << " - vIn.y * " << vSin << ");\n"
-		   << "\t\treal_t t = T(1.0) / d;\n"
+		   << "\t\treal_t t = (real_t)(1.0) / d;\n"
 		   << "\n"
 		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] * " << dist << " * vIn.x * t);\n"
 		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] * " << vfCos << " * vIn.y * t);\n"
@@ -1943,7 +1943,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t angle = MwcNext01(mwc) * M_2PI;\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - (real_t)(2.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * cos(angle);\n"
 		   << "\t\tvOut.y = r * sin(angle);\n"
@@ -1995,7 +1995,7 @@ public:
 		string zoom  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t rndG = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
+		   << "\t\treal_t rndG = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - (real_t)(2.0));\n"
 		   << "\t\treal_t ra = precalcSqrtSumSquares;\n"
 		   << "\t\treal_t tempa = precalcAtanyx + "<< spin << " * rndG;\n"
 		   << "\t\treal_t rz = " << zoom << " * rndG - 1;\n"
@@ -2070,7 +2070,7 @@ public:
 		string thickness = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + T(0.5));\n"
+		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + (real_t)(0.5));\n"
 		   << "\t\treal_t a = " << rotation << " + M_2PI * (sl + MwcNext01(mwc) * " << thickness << ") / " << slices << ";\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 		   << "\n"
@@ -2096,8 +2096,8 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Slices,    prefix + "pie_slices", 6, INTEGER_NONZERO, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie_rotation", T(T(0.5)), REAL_CYCLIC, 0, M_2PI));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie_thickness", T(T(0.5)), REAL, 0, 1));
+    m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie_rotation", T(0.5), REAL_CYCLIC, 0, M_2PI));
+    m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie_thickness", T(0.5), REAL, 0, 1));
 	}
 
 private:
@@ -2158,14 +2158,14 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t rFactor;\n"
 		   << "\n"
-		   << "\t\tif ((vIn.x == T(0.0)) && (vIn.y == T(0.0)))\n"
-		   << "\t\t	rFactor = T(0.0);\n"
+		   << "\t\tif ((vIn.x == (real_t)(0.0)) && (vIn.y == (real_t)(0.0)))\n"
+		   << "\t\t	rFactor = (real_t)(0.0);\n"
 		   << "\t\telse\n"
 		   << "\t\t	rFactor = pow(precalcSumSquares, " << cpower << ");\n"
 		   << "\n"
 		   << "\t\treal_t phi = precalcAtanyx - " << csides << " * floor(precalcAtanyx * " << csidesinv << ");\n"
 		   << "\n"
-		   << "\t\tif (phi > T(0.5) * " << csides << ")\n"
+		   << "\t\tif (phi > (real_t)(0.5) * " << csides << ")\n"
 		   << "\t\t	phi -= " << csides << ";\n"
 		   << "\n"
 		   << "\t\treal_t amp = (" << corners << " * (1 / cos(phi) - 1) + " << circle << ") * xform->m_VariationWeights[" << varIndex << "] * rFactor;\n"
@@ -2257,7 +2257,7 @@ public:
 		string c22 = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t re = T(1.0) + " << c1 << " * vIn.x + " << c2 << " * (SQR(vIn.x) - SQR(vIn.y));\n"
+		   << "\t\treal_t re = (real_t)(1.0) + " << c1 << " * vIn.x + " << c2 << " * (SQR(vIn.x) - SQR(vIn.y));\n"
 		   << "\t\treal_t im = " << c1 << " * vIn.y + " << c22 << " * vIn.x * vIn.y;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(SQR(re) + SQR(im));\n"
 		   << "\n"
@@ -2471,8 +2471,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - (real_t)(0.5));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - (real_t)(0.5));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -2597,14 +2597,14 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * precalcSqrtSumSquares;\n"
 		   << "\t\treal_t cr = cos(r);\n"
-		   << "\t\treal_t icr = T(1.0) / cr;\n"
+		   << "\t\treal_t icr = (real_t)(1.0) / cr;\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\n"
-		   << "\t\tif (cr < T(0.0))\n"
-		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr + T(1.0));\n"
+		   << "\t\tif (cr < (real_t)(0.0))\n"
+		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr + (real_t)(1.0));\n"
 		   << "\t\telse\n"
-		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr - T(1.0));\n"
+		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr - (real_t)(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
@@ -2652,7 +2652,7 @@ public:
 		   << "\t\treal_t diff = log10(sinr * sinr) + cosr;\n"
 		   << "\n"
 		   << "\t\tif (BadVal(diff))\n"
-		   << "\t\t	diff = -T(30.0);\n"
+		   << "\t\t	diff = -(real_t)(30.0);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x * diff;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.x * (diff - sinr * M_PI);\n"
@@ -2855,7 +2855,7 @@ public:
 		   << "\t\tt1 = pow(t1, " << n2 << ");\n"
 		   << "\t\treal_t t2 = fabs(sin(theta));\n"
 		   << "\t\tt2 = pow(t2, " << n3 << ");\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * ((" << rnd << " * MwcNext01(mwc) + (T(1.0) - " << rnd << ") * precalcSqrtSumSquares) - " << holes << ") * pow(t1 + t2, " << pNeg1N1 << ") / precalcSqrtSumSquares;\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * ((" << rnd << " * MwcNext01(mwc) + ((real_t)(1.0) - " << rnd << ") * precalcSqrtSumSquares) - " << holes << ") * pow(t1 + t2, " << pNeg1N1 << ") / precalcSqrtSumSquares;\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
 		   << "\t\tvOut.y = r * vIn.y;\n"
@@ -3263,7 +3263,7 @@ public:
 		   << "\t\treal_t t = x2y2 + 1;\n"
 		   << "\t\treal_t x2 = 2 * vIn.x;\n"
 		   << "\t\treal_t ps = " << s << ";\n"
-		   << "\t\treal_t y = T(0.5) * atan2(T(2.0) * vIn.y, x2y2 - T(1.0)) + ps;\n"
+		   << "\t\treal_t y = (real_t)(0.5) * atan2((real_t)(2.0) * vIn.y, x2y2 - (real_t)(1.0)) + ps;\n"
 		   << "\n"
 		   << "\t\tif (y > M_PI_2)\n"
 		   << "\t\t	y = -M_PI_2 + fmod(y + M_PI_2, M_PI);\n"
@@ -3416,37 +3416,37 @@ public:
 		   << "\t\treal_t offsetX = vIn.x - roundX;\n"
 		   << "\t\treal_t offsetY = vIn.y - roundY;\n"
 		   << "\n"
-		   << "\t\tif (MwcNext01(mwc) >= T(0.75))\n"
+		   << "\t\tif (MwcNext01(mwc) >= (real_t)(0.75))\n"
 		   << "\t\t{\n"
-		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX);\n"
-		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY);\n"
+		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX);\n"
+		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
 		   << "\t\t	if (fabs(offsetX) >= fabs(offsetY))\n"
 		   << "\t\t	{\n"
-		   << "\t\t		if (offsetX >= T(0.0))\n"
+		   << "\t\t		if (offsetX >= (real_t)(0.0))\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + T(0.25));\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + T(0.25) * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX + (real_t)(0.25));\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY + (real_t)(0.25) * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - T(0.25));\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - T(0.25) * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX - (real_t)(0.25));\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY - (real_t)(0.25) * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
 		   << "\t\t	{\n"
-		   << "\t\t		if (offsetY >= T(0.0))\n"
+		   << "\t\t		if (offsetY >= (real_t)(0.0))\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + T(0.25));\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + offsetX / offsetY * T(0.25));\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY + (real_t)(0.25));\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX + offsetX / offsetY * (real_t)(0.25));\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - T(0.25));\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - offsetX / offsetY * T(0.25));\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY - (real_t)(0.25));\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX - offsetX / offsetY * (real_t)(0.25));\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
@@ -3486,8 +3486,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t wx = xform->m_VariationWeights[" << varIndex << "] * T(1.3029400317411197908970256609023);\n"
-		   << "\t\treal_t y2 = vIn.y * T(2.0);\n"
+		   << "\t\treal_t wx = xform->m_VariationWeights[" << varIndex << "] * (real_t)(1.3029400317411197908970256609023);\n"
+		   << "\t\treal_t y2 = vIn.y * (real_t)(2.0);\n"
 		   << "\t\treal_t r = wx * sqrt(fabs(vIn.y * vIn.x) / Zeps(SQR(vIn.x) + SQR(y2)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
@@ -3569,7 +3569,7 @@ public:
 		string size = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t invCellSize = T(1.0) / " << size << ";\n"
+		   << "\t\treal_t invCellSize = (real_t)(1.0) / " << size << ";\n"
 		   //Float to int, orig.
 		   //<< "\t\tint x = (int)floor(vIn.x * invCellSize);\n"
 		   //<< "\t\tint y = (int)floor(vIn.y * invCellSize);\n"
@@ -3675,7 +3675,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t a = precalcAtanyx;\n"
-		   << "\t\treal_t lnr = T(0.5) * log(precalcSumSquares);\n"
+		   << "\t\treal_t lnr = (real_t)(0.5) * log(precalcSumSquares);\n"
 		   << "\t\treal_t angle = " << c << " * a + " << d << " * lnr + " << ang << " * floor(" << power << " * MwcNext01(mwc));\n"
 		   << "\t\treal_t m = xform->m_VariationWeights[" << varIndex << "] * exp(" << c << " * lnr - " << d << " * a);\n"
 		   << "\n"
@@ -3854,14 +3854,14 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t tmp = precalcSumSquares + T(1.0);\n"
-		   << "\t\treal_t tmp2 = T(2.0) * vIn.x;\n"
+		   << "\t\treal_t tmp = precalcSumSquares + (real_t)(1.0);\n"
+		   << "\t\treal_t tmp2 = (real_t)(2.0) * vIn.x;\n"
 		   << "\t\treal_t r1 = sqrt(tmp + tmp2);\n"
 		   << "\t\treal_t r2 = sqrt(tmp - tmp2);\n"
-		   << "\t\treal_t xmax = (r1 + r2) * T(0.5);\n"
-		   << "\t\treal_t a1 = log(xmax + sqrt(xmax - T(1.0)));\n"
-		   << "\t\treal_t a2 = -acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
-		   << "\t\treal_t w = xform->m_VariationWeights[" << varIndex << "] / T(11.57034632);\n"
+		   << "\t\treal_t xmax = (r1 + r2) * (real_t)(0.5);\n"
+		   << "\t\treal_t a1 = log(xmax + sqrt(xmax - (real_t)(1.0)));\n"
+		   << "\t\treal_t a2 = -acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
+		   << "\t\treal_t w = xform->m_VariationWeights[" << varIndex << "] / (real_t)(11.57034632);\n"
 		   << "\t\treal_t snv = sin(a1);\n"
 		   << "\t\treal_t csv = cos(a1);\n"
 		   << "\t\treal_t snhu = sinh(a2);\n"
@@ -3932,12 +3932,12 @@ public:
 		string weightDivPiDiv2 = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tmp = precalcSumSquares + T(1.0);\n"
-		   << "\t\treal_t x2 = T(2.0) * vIn.x;\n"
-		   << "\t\treal_t xmax = T(0.5) * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
+		   << "\t\treal_t tmp = precalcSumSquares + (real_t)(1.0);\n"
+		   << "\t\treal_t x2 = (real_t)(2.0) * vIn.x;\n"
+		   << "\t\treal_t xmax = (real_t)(0.5) * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
 		   << "\t\treal_t a = vIn.x / xmax;\n"
-		   << "\t\treal_t b = T(1.0) - a * a;\n"
-		   << "\t\treal_t ssx = xmax - T(1.0);\n"
+		   << "\t\treal_t b = (real_t)(1.0) - a * a;\n"
+		   << "\t\treal_t ssx = xmax - (real_t)(1.0);\n"
 		   << "\t\tconst real_t w = " << weightDivPiDiv2 << ";\n"
 		   << "\n"
 		   << "\t\tif (b < 0)\n"
@@ -4019,7 +4019,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t a = precalcAtanyx;\n"
-		   << "\t\treal_t lnr = T(0.5) * log(precalcSumSquares);\n"
+		   << "\t\treal_t lnr = (real_t)(0.5) * log(precalcSumSquares);\n"
 		   << "\t\treal_t m = xform->m_VariationWeights[" << varIndex << "] * exp(" << c << " * lnr - " << d << " * a);\n"
 		   << "\t\treal_t n = " << c << " * a + " << d << " * lnr;\n"
 		   << "\n"
@@ -4104,8 +4104,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t expx = exp(vIn.x) * T(0.5);\n"
-		   << "\t\treal_t expnx = T(0.25) / expx;\n"
+		   << "\t\treal_t expx = exp(vIn.x) * (real_t)(0.5);\n"
+		   << "\t\treal_t expnx = (real_t)(0.25) / expx;\n"
 		   << "\t\treal_t sn = sin(vIn.y);\n"
 		   << "\t\treal_t cn = cos(vIn.y);\n"
 		   << "\t\treal_t tmp = Zeps(expx + expnx - cn);\n"
@@ -4185,7 +4185,7 @@ public:
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
-		   << "\t\t	r = T(1.0) + " << space << " / Zeps(r);\n"
+		   << "\t\t	r = (real_t)(1.0) + " << space << " / Zeps(r);\n"
 		   << "\n"
 		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (r * x + " << x << ");\n"
 		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (r * y - " << y << ");\n"
@@ -4282,7 +4282,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\tif (precalcSumSquares < " << w2 << " && precalcSumSquares != 0)\n"
 		   << "\t\t{\n"
-		   << "\t\t	real_t r = xform->m_VariationWeights[" << varIndex << "] * sqrt((" << w2 << " / precalcSumSquares) - T(1.0));\n"
+		   << "\t\t	real_t r = xform->m_VariationWeights[" << varIndex << "] * sqrt((" << w2 << " / precalcSumSquares) - (real_t)(1.0));\n"
 		   << "\t\t	vOut.x = r * vIn.x;\n"
 		   << "\t\t	vOut.y = r * vIn.y;\n"
 		   << "\t\t}\n"
@@ -4464,7 +4464,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t t;\n"
 		   << "\n"
-		   << "\t\tif (" << damping << " == T(0.0))\n"
+		   << "\t\tif (" << damping << " == (real_t)(0.0))\n"
 		   << "\t\t	t = " << amplitude << " * cos(" << tpf << " * vIn.x) + " << separation << ";\n"
 		   << "\t\telse\n"
 		   << "\t\t	t = " << amplitude << " * exp(-fabs(vIn.x) * " << damping << ") * cos(" << tpf << " * vIn.x) + " << separation << ";\n"
@@ -4633,8 +4633,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_x", T(T(0.1))));
-		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_y", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_x", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_y", T(0.1)));
 		m_Params.push_back(ParamWithName<T>(&m_C, prefix + "popcorn2_c", 3));
 	}
 
@@ -4681,7 +4681,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t t = precalcSumSquares;\n"
-		   << "\t\treal_t r = T(1.0) / Zeps(precalcSqrtSumSquares * (t + " << invWeight << "));\n"
+		   << "\t\treal_t r = (real_t)(1.0) / Zeps(precalcSqrtSumSquares * (t + " << invWeight << "));\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * r;\n"
 		   << "\t\tvOut.y = vIn.y * r;\n"
@@ -4752,12 +4752,12 @@ public:
 		string yy      = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tif (vIn.x > T(0.0))\n"
+		   << "\t\tif (vIn.x > (real_t)(0.0))\n"
 		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.x * vIn.x + " << xx << ") - vIn.x * " << xInside << ");\n"
 		   << "\t\telse\n"
 		   << "\t\t	vOut.x = -(xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.x * vIn.x + " << xx << ") + vIn.x * " << xInside << "));\n"
 		   << "\n"
-		   << "\t\tif (vIn.y > T(0.0))\n"
+		   << "\t\tif (vIn.y > (real_t)(0.0))\n"
 		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.y * vIn.y + " << yy << ") - vIn.y * " << yInside << ");\n"
 		   << "\t\telse\n"
 		   << "\t\t	vOut.y = -(xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.y * vIn.y + " << yy << ") + vIn.y * " << yInside << "));\n"
@@ -4880,8 +4880,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_XSize, prefix + "split_xsize", T(T(0.5))));//Params.
-		m_Params.push_back(ParamWithName<T>(&m_YSize, prefix + "split_ysize", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_XSize, prefix + "split_xsize", T(0.5)));//Params.
+		m_Params.push_back(ParamWithName<T>(&m_YSize, prefix + "split_ysize", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(true, &m_XAng, prefix + "split_xang"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_YAng, prefix + "split_yang"));
 	}
@@ -5003,10 +5003,10 @@ public:
 		string warp  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t roundx = (real_t)(int)(vIn.x >= 0 ? (vIn.x + T(0.5)) : (vIn.x - T(0.5)));\n"
+		   << "\t\treal_t roundx = (real_t)(int)(vIn.x >= 0 ? (vIn.x + (real_t)(0.5)) : (vIn.x - (real_t)(0.5)));\n"
 		   << "\t\treal_t offsetx = vIn.x - roundx;\n"
 		   << "\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetx * (T(1.0) - " << space << ") + roundx);\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetx * ((real_t)(1.0) - " << space << ") + roundx);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + offsetx * offsetx * " << warp << ");\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
@@ -5026,7 +5026,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Space, prefix + "stripes_space", T(T(0.5)), REAL, T(T(0.5)), 5));
+		m_Params.push_back(ParamWithName<T>(&m_Space, prefix + "stripes_space", T(0.5), REAL, T(0.5), 5));
 		m_Params.push_back(ParamWithName<T>(&m_Warp,  prefix + "stripes_warp"));
 	}
 
@@ -5077,7 +5077,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t r = precalcSqrtSumSquares;\n"
 		   << "\t\treal_t a = precalcAtanyx + " << swirl << " * r;\n"
-		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * T(0.5));\n"
+		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * (real_t)(0.5));\n"
 		   << "\n"
 		   << "\t\ta = a * " << compFac << " + c * " << angle << ";\n"
 		   << "\t\tr = xform->m_VariationWeights[" << varIndex << "] * (r + " << hole << ");\n"
@@ -5168,7 +5168,7 @@ public:
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * pow(precalcSumSquares, " << cn << ");\n"
 		   << "\t\tint tRand = (int)(" << rn << " * MwcNext01(mwc));\n"
 		   << "\t\treal_t a = (precalcAtanyx + M_2PI * tRand) / " << power << ";\n"
-		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * T(0.5));\n"
+		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * (real_t)(0.5));\n"
 		   << "\n"
 		   << "\t\ta = a * " << cf << " + c * " << angle << ";\n"
 		   << "\t\tvOut.x = r * cos(a);\n"
@@ -5259,10 +5259,10 @@ public:
 		string swirl = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = T(1.0) / Zeps(precalcSqrtSumSquares);\n"
+		   << "\t\treal_t r = (real_t)(1.0) / Zeps(precalcSqrtSumSquares);\n"
 		   << "\t\treal_t a = precalcAtanyx + " << swirl << " * r;\n"
-		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * T(0.5));\n"
-		   << "\t\treal_t compFac = 1 - " << angle << " * " << count << " * M_1_PI * T(0.5);\n"
+		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * (real_t)(0.5));\n"
+		   << "\t\treal_t compFac = 1 - " << angle << " * " << count << " * M_1_PI * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\ta = a * compFac + c * " << angle << ";\n"
 		   << "\t\tr = xform->m_VariationWeights[" << varIndex << "] * (r + " << hole << ");\n"
@@ -5645,11 +5645,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t tansin = sin(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t tancos = cos(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t tansinh = sinh(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t tancosh = cosh(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t tanden = T(1.0) / (tancos + tancosh);\n"
+		   << "\t\treal_t tansin = sin((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t tancos = cos((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t tansinh = sinh((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t tancosh = cosh((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t tanden = (real_t)(1.0) / (tancos + tancosh);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * tanden * tansin;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * tanden * tansinh;\n"
@@ -5694,7 +5694,7 @@ public:
 		   << "\t\treal_t seccos = cos(vIn.x);\n"
 		   << "\t\treal_t secsinh = sinh(vIn.y);\n"
 		   << "\t\treal_t seccosh = cosh(vIn.y);\n"
-		   << "\t\treal_t secden = T(2.0) / (cos(T(2.0) * vIn.x) + cosh(T(2.0) * vIn.y));\n"
+		   << "\t\treal_t secden = (real_t)(2.0) / (cos((real_t)(2.0) * vIn.x) + cosh((real_t)(2.0) * vIn.y));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * secden * seccos * seccosh;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * secden * secsin * secsinh;\n"
@@ -5739,7 +5739,7 @@ public:
 		   << "\t\treal_t csccos = cos(vIn.x);\n"
 		   << "\t\treal_t cscsinh = sinh(vIn.y);\n"
 		   << "\t\treal_t csccosh = cosh(vIn.y);\n"
-		   << "\t\treal_t cscden = T(2.0) / (cosh(T(2.0) * vIn.y) - cos(T(2.0) * vIn.x));\n"
+		   << "\t\treal_t cscden = (real_t)(2.0) / (cosh((real_t)(2.0) * vIn.y) - cos((real_t)(2.0) * vIn.x));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cscden * cscsin * csccosh;\n"
 		   << "\t\tvOut.y = -(xform->m_VariationWeights[" << varIndex << "] * cscden * csccos * cscsinh);\n"
@@ -5780,11 +5780,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t cotsin = sin(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t cotcos = cos(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t cotsinh = sinh(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t cotcosh = cosh(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t cotden = T(1.0) / (cotcosh - cotcos);\n"
+		   << "\t\treal_t cotsin = sin((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t cotcos = cos((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t cotsinh = sinh((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t cotcosh = cosh((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t cotden = (real_t)(1.0) / (cotcosh - cotcos);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cotden * cotsin;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cotden * -1 * cotsinh;\n"
@@ -5911,11 +5911,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t tanhsin = sin(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t tanhcos = cos(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t tanhsinh = sinh(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t tanhcosh = cosh(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t tanhden = T(1.0) / (tanhcos + tanhcosh);\n"
+		   << "\t\treal_t tanhsin = sin((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t tanhcos = cos((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t tanhsinh = sinh((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t tanhcosh = cosh((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t tanhden = (real_t)(1.0) / (tanhcos + tanhcosh);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * tanhden * tanhsinh;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * tanhden * tanhsin;\n"
@@ -5960,7 +5960,7 @@ public:
 		   << "\t\treal_t sechcos = cos(vIn.y);\n"
 		   << "\t\treal_t sechsinh = sinh(vIn.x);\n"
 		   << "\t\treal_t sechcosh = cosh(vIn.x);\n"
-		   << "\t\treal_t sechden = T(2.0) / (cos(T(2.0) * vIn.y) + cosh(T(2.0) * vIn.x));\n"
+		   << "\t\treal_t sechden = (real_t)(2.0) / (cos((real_t)(2.0) * vIn.y) + cosh((real_t)(2.0) * vIn.x));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * sechden * sechcos * sechcosh;\n"
 		   << "\t\tvOut.y = -(xform->m_VariationWeights[" << varIndex << "] * sechden * sechsin * sechsinh);\n"
@@ -6005,7 +6005,7 @@ public:
 		   << "\t\treal_t cschcos = cos(vIn.y);\n"
 		   << "\t\treal_t cschsinh = sinh(vIn.x);\n"
 		   << "\t\treal_t cschcosh = cosh(vIn.x);\n"
-		   << "\t\treal_t cschden = T(2.0) / (cosh(T(2.0) * vIn.x) - cos(T(2.0) * vIn.y));\n"
+		   << "\t\treal_t cschden = (real_t)(2.0) / (cosh((real_t)(2.0) * vIn.x) - cos((real_t)(2.0) * vIn.y));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cschden * cschsinh * cschcos;\n"
 		   << "\t\tvOut.y = -(xform->m_VariationWeights[" << varIndex << "] * cschden * cschcosh * cschsin);\n"
@@ -6046,11 +6046,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t cothsin = sin(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t cothcos = cos(T(2.0) * vIn.y);\n"
-		   << "\t\treal_t cothsinh = sinh(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t cothcosh = cosh(T(2.0) * vIn.x);\n"
-		   << "\t\treal_t cothden = T(1.0) / (cothcosh - cothcos);\n"
+		   << "\t\treal_t cothsin = sin((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t cothcos = cos((real_t)(2.0) * vIn.y);\n"
+		   << "\t\treal_t cothsinh = sinh((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t cothcosh = cosh((real_t)(2.0) * vIn.x);\n"
+		   << "\t\treal_t cothden = (real_t)(1.0) / (cothcosh - cothcos);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cothden * cothsinh;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cothden * cothsin;\n"
@@ -6101,8 +6101,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t s = sin(" << freq << " * vIn.x);\n"
 		   << "\t\treal_t t = sin(" << freq << " * vIn.y);\n"
-		   << "\t\treal_t dy = vIn.y + " << augerWeight << " * (" << scale << " * s / T(2.0) + fabs(vIn.y) * s);\n"
-		   << "\t\treal_t dx = vIn.x + " << augerWeight << " * (" << scale << " * t / T(2.0) + fabs(vIn.x) * t);\n"
+		   << "\t\treal_t dy = vIn.y + " << augerWeight << " * (" << scale << " * s / (real_t)(2.0) + fabs(vIn.y) * s);\n"
+		   << "\t\treal_t dx = vIn.x + " << augerWeight << " * (" << scale << " * t / (real_t)(2.0) + fabs(vIn.x) * t);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + " << symmetry << " * (dx - vIn.x));\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * dy;\n"
@@ -6127,9 +6127,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Symmetry,    prefix + "auger_sym"));
-		m_Params.push_back(ParamWithName<T>(&m_AugerWeight, prefix + "auger_weight", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_AugerWeight, prefix + "auger_weight", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Freq,        prefix + "auger_freq", 5));
-		m_Params.push_back(ParamWithName<T>(&m_Scale,       prefix + "auger_scale", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_Scale,       prefix + "auger_scale", T(0.1)));
 	}
 
 private:
@@ -6187,11 +6187,11 @@ public:
 		   << "\t\treal_t yy = SQR(vIn.y);\n"
 		   << "\t\treal_t frac = sqrt(yy + SQR(xmw));\n"
 		   << "\n"
-		   << "\t\tif (frac == T(0.0))\n"
-		   << "\t\t	frac = T(1.0);\n"
+		   << "\t\tif (frac == (real_t)(0.0))\n"
+		   << "\t\t	frac = (real_t)(1.0);\n"
 		   << "\n"
 		   << "\t\treal_t avgr = xform->m_VariationWeights[" << varIndex << "] * (" << spr << " * sqrt(sqrt(yy + SQR(xpw)) / frac));\n"
-		   << "\t\treal_t avga = (atan2(vIn.y, xmw) - atan2(vIn.y, xpw)) * T(0.5);\n"
+		   << "\t\treal_t avga = (atan2(vIn.y, xmw) - atan2(vIn.y, xpw)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tvOut.x = avgr * cos(avga);\n"
 		   << "\t\tvOut.y = avgr * sin(avga);\n"

--- a/Source/Ember/Variations01.h
+++ b/Source/Ember/Variations01.h
@@ -202,7 +202,7 @@ public:
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(precalcSqrtSumSquares);\n"
 		   << "\n"
 		   << "\t\tvOut.x = (vIn.x - vIn.y) * (vIn.x + vIn.y) * r;\n"
-		   << "\t\tvOut.y = 2.0 * vIn.x * vIn.y * r;\n"
+		   << "\t\tvOut.y = T(2.0) * vIn.x * vIn.y * r;\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -239,7 +239,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (precalcAtanxy * M_1_PI);\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (precalcSqrtSumSquares - 1.0);\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (precalcSqrtSumSquares - T(1.0));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -610,7 +610,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * sqrt(precalcSqrtSumSquares);\n"
-		   << "\t\treal_t a = 0.5 * precalcAtanxy;\n"
+		   << "\t\treal_t a = T(0.5) * precalcAtanxy;\n"
 		   << "\n"
 		   << "\t\tif (MwcNext(mwc) & 1)\n"
 		   << "\t\t	a += M_PI;\n"
@@ -657,8 +657,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t nx = vIn.x < 0.0 ? (vIn.x * 2.0) : vIn.x;\n"
-		   << "\t\treal_t ny = vIn.y < 0.0 ? (vIn.y / 2.0) : vIn.y;\n"
+		   << "\t\treal_t nx = vIn.x < T(0.0) ? (vIn.x * T(2.0)) : vIn.x;\n"
+		   << "\t\treal_t ny = vIn.y < T(0.0) ? (vIn.y / T(2.0)) : vIn.y;\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * nx;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * ny;\n"
@@ -878,7 +878,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t dx = xform->m_VariationWeights[" << varIndex << "] * exp(vIn.x - 1.0);\n"
+		   << "\t\treal_t dx = xform->m_VariationWeights[" << varIndex << "] * exp(vIn.x - T(1.0));\n"
 		   << "\t\treal_t dy = M_PI * vIn.y;\n"
 		   << "\n"
 		   << "\t\tvOut.x = dx * cos(dy);\n"
@@ -1074,7 +1074,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t dx = M_PI * Zeps(xform->m_C * xform->m_C);\n"
 		   << "\t\treal_t dy = xform->m_F;\n"
-		   << "\t\treal_t dx2 = 0.5 * dx;\n"
+		   << "\t\treal_t dx2 = T(0.5) * dx;\n"
 		   << "\t\treal_t a = precalcAtanxy + ((fmod(precalcAtanxy + dy, dx) > dx2) ? -dx2 : dx2);\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * precalcSqrtSumSquares;\n"
 		   << "\n"
@@ -1130,7 +1130,7 @@ public:
 		string blobDiff  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * (0.5 + 0.5 * sin(" << blobWaves << " * precalcAtanxy)));\n"
+		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * (T(0.5) + T(0.5) * sin(" << blobWaves << " * precalcAtanxy)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] * precalcSina * r);\n"
 		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] * precalcCosa * r);\n"
@@ -1408,7 +1408,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t r = precalcSqrtSumSquares;\n"
 		   << "\n"
-		   << "\t\tr += -2.0 * " << rings2Val2 << " * (int)((r + " << rings2Val2 << ") / (2.0 * " << rings2Val2 << ")) + r * (1.0 - " << rings2Val2 << ");\n"
+		   << "\t\tr += -T(2.0) * " << rings2Val2 << " * (int)((r + " << rings2Val2 << ") / (T(2.0) * " << rings2Val2 << ")) + r * (T(1.0) - " << rings2Val2 << ");\n"
 		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] * precalcSina * r);\n"
 		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] * precalcCosa * r);\n"
 		   << "\t\tvOut.z =  xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
@@ -1471,7 +1471,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = (xform->m_VariationWeights[" << varIndex << "] * 2.0) / (precalcSqrtSumSquares + 1.0);\n"
+		   << "\t\treal_t r = (xform->m_VariationWeights[" << varIndex << "] * T(2.0)) / (precalcSqrtSumSquares + T(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
 		   << "\t\tvOut.y = r * vIn.y;\n"
@@ -1509,7 +1509,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t denom = 0.25 * precalcSumSquares + 1;\n"
+		   << "\t\treal_t denom = T(0.25) * precalcSumSquares + 1;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / denom;\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
@@ -1591,7 +1591,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t d = Zeps(" << dist << " - vIn.y * " << vSin << ");\n"
-		   << "\t\treal_t t = 1.0 / d;\n"
+		   << "\t\treal_t t = T(1.0) / d;\n"
 		   << "\n"
 		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] * " << dist << " * vIn.x * t);\n"
 		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] * " << vfCos << " * vIn.y * t);\n"
@@ -1943,7 +1943,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t angle = MwcNext01(mwc) * M_2PI;\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - 2.0);\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * cos(angle);\n"
 		   << "\t\tvOut.y = r * sin(angle);\n"
@@ -1995,7 +1995,7 @@ public:
 		string zoom  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t rndG = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - 2.0);\n"
+		   << "\t\treal_t rndG = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
 		   << "\t\treal_t ra = precalcSqrtSumSquares;\n"
 		   << "\t\treal_t tempa = precalcAtanyx + "<< spin << " * rndG;\n"
 		   << "\t\treal_t rz = " << zoom << " * rndG - 1;\n"
@@ -2070,7 +2070,7 @@ public:
 		string thickness = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + 0.5);\n"
+		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + T(0.5));\n"
 		   << "\t\treal_t a = " << rotation << " + M_2PI * (sl + MwcNext01(mwc) * " << thickness << ") / " << slices << ";\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 		   << "\n"
@@ -2096,8 +2096,8 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Slices,    prefix + "pie_slices", 6, INTEGER_NONZERO, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie_rotation", T(0.5), REAL_CYCLIC, 0, M_2PI));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie_thickness", T(0.5), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie_rotation", T(T(0.5)), REAL_CYCLIC, 0, M_2PI));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie_thickness", T(T(0.5)), REAL, 0, 1));
 	}
 
 private:
@@ -2158,14 +2158,14 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t rFactor;\n"
 		   << "\n"
-		   << "\t\tif ((vIn.x == 0.0) && (vIn.y == 0.0))\n"
-		   << "\t\t	rFactor = 0.0;\n"
+		   << "\t\tif ((vIn.x == T(0.0)) && (vIn.y == T(0.0)))\n"
+		   << "\t\t	rFactor = T(0.0);\n"
 		   << "\t\telse\n"
 		   << "\t\t	rFactor = pow(precalcSumSquares, " << cpower << ");\n"
 		   << "\n"
 		   << "\t\treal_t phi = precalcAtanyx - " << csides << " * floor(precalcAtanyx * " << csidesinv << ");\n"
 		   << "\n"
-		   << "\t\tif (phi > 0.5 * " << csides << ")\n"
+		   << "\t\tif (phi > T(0.5) * " << csides << ")\n"
 		   << "\t\t	phi -= " << csides << ";\n"
 		   << "\n"
 		   << "\t\treal_t amp = (" << corners << " * (1 / cos(phi) - 1) + " << circle << ") * xform->m_VariationWeights[" << varIndex << "] * rFactor;\n"
@@ -2257,7 +2257,7 @@ public:
 		string c22 = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t re = 1.0 + " << c1 << " * vIn.x + " << c2 << " * (SQR(vIn.x) - SQR(vIn.y));\n"
+		   << "\t\treal_t re = T(1.0) + " << c1 << " * vIn.x + " << c2 << " * (SQR(vIn.x) - SQR(vIn.y));\n"
 		   << "\t\treal_t im = " << c1 << " * vIn.y + " << c22 << " * vIn.x * vIn.y;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(SQR(re) + SQR(im));\n"
 		   << "\n"
@@ -2471,8 +2471,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - 0.5);\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - 0.5);\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -2597,14 +2597,14 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * precalcSqrtSumSquares;\n"
 		   << "\t\treal_t cr = cos(r);\n"
-		   << "\t\treal_t icr = 1.0 / cr;\n"
+		   << "\t\treal_t icr = T(1.0) / cr;\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\n"
-		   << "\t\tif (cr < 0.0)\n"
-		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr + 1.0);\n"
+		   << "\t\tif (cr < T(0.0))\n"
+		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr + T(1.0));\n"
 		   << "\t\telse\n"
-		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr - 1.0);\n"
+		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (icr - T(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
@@ -2652,7 +2652,7 @@ public:
 		   << "\t\treal_t diff = log10(sinr * sinr) + cosr;\n"
 		   << "\n"
 		   << "\t\tif (BadVal(diff))\n"
-		   << "\t\t	diff = -30.0;\n"
+		   << "\t\t	diff = -T(30.0);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x * diff;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.x * (diff - sinr * M_PI);\n"
@@ -2855,7 +2855,7 @@ public:
 		   << "\t\tt1 = pow(t1, " << n2 << ");\n"
 		   << "\t\treal_t t2 = fabs(sin(theta));\n"
 		   << "\t\tt2 = pow(t2, " << n3 << ");\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * ((" << rnd << " * MwcNext01(mwc) + (1.0 - " << rnd << ") * precalcSqrtSumSquares) - " << holes << ") * pow(t1 + t2, " << pNeg1N1 << ") / precalcSqrtSumSquares;\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * ((" << rnd << " * MwcNext01(mwc) + (T(1.0) - " << rnd << ") * precalcSqrtSumSquares) - " << holes << ") * pow(t1 + t2, " << pNeg1N1 << ") / precalcSqrtSumSquares;\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
 		   << "\t\tvOut.y = r * vIn.y;\n"
@@ -3263,7 +3263,7 @@ public:
 		   << "\t\treal_t t = x2y2 + 1;\n"
 		   << "\t\treal_t x2 = 2 * vIn.x;\n"
 		   << "\t\treal_t ps = " << s << ";\n"
-		   << "\t\treal_t y = 0.5 * atan2(2.0 * vIn.y, x2y2 - 1.0) + ps;\n"
+		   << "\t\treal_t y = T(0.5) * atan2(T(2.0) * vIn.y, x2y2 - T(1.0)) + ps;\n"
 		   << "\n"
 		   << "\t\tif (y > M_PI_2)\n"
 		   << "\t\t	y = -M_PI_2 + fmod(y + M_PI_2, M_PI);\n"
@@ -3416,37 +3416,37 @@ public:
 		   << "\t\treal_t offsetX = vIn.x - roundX;\n"
 		   << "\t\treal_t offsetY = vIn.y - roundY;\n"
 		   << "\n"
-		   << "\t\tif (MwcNext01(mwc) >= 0.75)\n"
+		   << "\t\tif (MwcNext01(mwc) >= T(0.75))\n"
 		   << "\t\t{\n"
-		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX);\n"
-		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY);\n"
+		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX);\n"
+		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
 		   << "\t\t	if (fabs(offsetX) >= fabs(offsetY))\n"
 		   << "\t\t	{\n"
-		   << "\t\t		if (offsetX >= 0.0)\n"
+		   << "\t\t		if (offsetX >= T(0.0))\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX + 0.25);\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY + 0.25 * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + T(0.25));\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + T(0.25) * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX - 0.25);\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY - 0.25 * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - T(0.25));\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - T(0.25) * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
 		   << "\t\t	{\n"
-		   << "\t\t		if (offsetY >= 0.0)\n"
+		   << "\t\t		if (offsetY >= T(0.0))\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY + 0.25);\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX + offsetX / offsetY * 0.25);\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + T(0.25));\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + offsetX / offsetY * T(0.25));\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY - 0.25);\n"
-		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX - offsetX / offsetY * 0.25);\n"
+		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - T(0.25));\n"
+		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - offsetX / offsetY * T(0.25));\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
@@ -3486,8 +3486,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t wx = xform->m_VariationWeights[" << varIndex << "] * 1.3029400317411197908970256609023;\n"
-		   << "\t\treal_t y2 = vIn.y * 2.0;\n"
+		   << "\t\treal_t wx = xform->m_VariationWeights[" << varIndex << "] * T(1.3029400317411197908970256609023);\n"
+		   << "\t\treal_t y2 = vIn.y * T(2.0);\n"
 		   << "\t\treal_t r = wx * sqrt(fabs(vIn.y * vIn.x) / Zeps(SQR(vIn.x) + SQR(y2)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * vIn.x;\n"
@@ -3569,7 +3569,7 @@ public:
 		string size = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t invCellSize = 1.0 / " << size << ";\n"
+		   << "\t\treal_t invCellSize = T(1.0) / " << size << ";\n"
 		   //Float to int, orig.
 		   //<< "\t\tint x = (int)floor(vIn.x * invCellSize);\n"
 		   //<< "\t\tint y = (int)floor(vIn.y * invCellSize);\n"
@@ -3675,7 +3675,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t a = precalcAtanyx;\n"
-		   << "\t\treal_t lnr = 0.5 * log(precalcSumSquares);\n"
+		   << "\t\treal_t lnr = T(0.5) * log(precalcSumSquares);\n"
 		   << "\t\treal_t angle = " << c << " * a + " << d << " * lnr + " << ang << " * floor(" << power << " * MwcNext01(mwc));\n"
 		   << "\t\treal_t m = xform->m_VariationWeights[" << varIndex << "] * exp(" << c << " * lnr - " << d << " * a);\n"
 		   << "\n"
@@ -3854,14 +3854,14 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t tmp = precalcSumSquares + 1.0;\n"
-		   << "\t\treal_t tmp2 = 2.0 * vIn.x;\n"
+		   << "\t\treal_t tmp = precalcSumSquares + T(1.0);\n"
+		   << "\t\treal_t tmp2 = T(2.0) * vIn.x;\n"
 		   << "\t\treal_t r1 = sqrt(tmp + tmp2);\n"
 		   << "\t\treal_t r2 = sqrt(tmp - tmp2);\n"
-		   << "\t\treal_t xmax = (r1 + r2) * 0.5;\n"
-		   << "\t\treal_t a1 = log(xmax + sqrt(xmax - 1.0));\n"
-		   << "\t\treal_t a2 = -acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
-		   << "\t\treal_t w = xform->m_VariationWeights[" << varIndex << "] / 11.57034632;\n"
+		   << "\t\treal_t xmax = (r1 + r2) * T(0.5);\n"
+		   << "\t\treal_t a1 = log(xmax + sqrt(xmax - T(1.0)));\n"
+		   << "\t\treal_t a2 = -acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t w = xform->m_VariationWeights[" << varIndex << "] / T(11.57034632);\n"
 		   << "\t\treal_t snv = sin(a1);\n"
 		   << "\t\treal_t csv = cos(a1);\n"
 		   << "\t\treal_t snhu = sinh(a2);\n"
@@ -3932,12 +3932,12 @@ public:
 		string weightDivPiDiv2 = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tmp = precalcSumSquares + 1.0;\n"
-		   << "\t\treal_t x2 = 2.0 * vIn.x;\n"
-		   << "\t\treal_t xmax = 0.5 * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
+		   << "\t\treal_t tmp = precalcSumSquares + T(1.0);\n"
+		   << "\t\treal_t x2 = T(2.0) * vIn.x;\n"
+		   << "\t\treal_t xmax = T(0.5) * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
 		   << "\t\treal_t a = vIn.x / xmax;\n"
-		   << "\t\treal_t b = 1.0 - a * a;\n"
-		   << "\t\treal_t ssx = xmax - 1.0;\n"
+		   << "\t\treal_t b = T(1.0) - a * a;\n"
+		   << "\t\treal_t ssx = xmax - T(1.0);\n"
 		   << "\t\tconst real_t w = " << weightDivPiDiv2 << ";\n"
 		   << "\n"
 		   << "\t\tif (b < 0)\n"
@@ -4019,7 +4019,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t a = precalcAtanyx;\n"
-		   << "\t\treal_t lnr = 0.5 * log(precalcSumSquares);\n"
+		   << "\t\treal_t lnr = T(0.5) * log(precalcSumSquares);\n"
 		   << "\t\treal_t m = xform->m_VariationWeights[" << varIndex << "] * exp(" << c << " * lnr - " << d << " * a);\n"
 		   << "\t\treal_t n = " << c << " * a + " << d << " * lnr;\n"
 		   << "\n"
@@ -4104,8 +4104,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t expx = exp(vIn.x) * 0.5;\n"
-		   << "\t\treal_t expnx = 0.25 / expx;\n"
+		   << "\t\treal_t expx = exp(vIn.x) * T(0.5);\n"
+		   << "\t\treal_t expnx = T(0.25) / expx;\n"
 		   << "\t\treal_t sn = sin(vIn.y);\n"
 		   << "\t\treal_t cn = cos(vIn.y);\n"
 		   << "\t\treal_t tmp = Zeps(expx + expnx - cn);\n"
@@ -4185,7 +4185,7 @@ public:
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
-		   << "\t\t	r = 1.0 + " << space << " / Zeps(r);\n"
+		   << "\t\t	r = T(1.0) + " << space << " / Zeps(r);\n"
 		   << "\n"
 		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (r * x + " << x << ");\n"
 		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (r * y - " << y << ");\n"
@@ -4282,7 +4282,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\tif (precalcSumSquares < " << w2 << " && precalcSumSquares != 0)\n"
 		   << "\t\t{\n"
-		   << "\t\t	real_t r = xform->m_VariationWeights[" << varIndex << "] * sqrt((" << w2 << " / precalcSumSquares) - 1.0);\n"
+		   << "\t\t	real_t r = xform->m_VariationWeights[" << varIndex << "] * sqrt((" << w2 << " / precalcSumSquares) - T(1.0));\n"
 		   << "\t\t	vOut.x = r * vIn.x;\n"
 		   << "\t\t	vOut.y = r * vIn.y;\n"
 		   << "\t\t}\n"
@@ -4464,7 +4464,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t t;\n"
 		   << "\n"
-		   << "\t\tif (" << damping << " == 0.0)\n"
+		   << "\t\tif (" << damping << " == T(0.0))\n"
 		   << "\t\t	t = " << amplitude << " * cos(" << tpf << " * vIn.x) + " << separation << ";\n"
 		   << "\t\telse\n"
 		   << "\t\t	t = " << amplitude << " * exp(-fabs(vIn.x) * " << damping << ") * cos(" << tpf << " * vIn.x) + " << separation << ";\n"
@@ -4633,8 +4633,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_x", T(0.1)));
-		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_y", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_x", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_y", T(T(0.1))));
 		m_Params.push_back(ParamWithName<T>(&m_C, prefix + "popcorn2_c", 3));
 	}
 
@@ -4681,7 +4681,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t t = precalcSumSquares;\n"
-		   << "\t\treal_t r = 1.0 / Zeps(precalcSqrtSumSquares * (t + " << invWeight << "));\n"
+		   << "\t\treal_t r = T(1.0) / Zeps(precalcSqrtSumSquares * (t + " << invWeight << "));\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * r;\n"
 		   << "\t\tvOut.y = vIn.y * r;\n"
@@ -4752,12 +4752,12 @@ public:
 		string yy      = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tif (vIn.x > 0.0)\n"
+		   << "\t\tif (vIn.x > T(0.0))\n"
 		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.x * vIn.x + " << xx << ") - vIn.x * " << xInside << ");\n"
 		   << "\t\telse\n"
 		   << "\t\t	vOut.x = -(xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.x * vIn.x + " << xx << ") + vIn.x * " << xInside << "));\n"
 		   << "\n"
-		   << "\t\tif (vIn.y > 0.0)\n"
+		   << "\t\tif (vIn.y > T(0.0))\n"
 		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.y * vIn.y + " << yy << ") - vIn.y * " << yInside << ");\n"
 		   << "\t\telse\n"
 		   << "\t\t	vOut.y = -(xform->m_VariationWeights[" << varIndex << "] * (sqrt(vIn.y * vIn.y + " << yy << ") + vIn.y * " << yInside << "));\n"
@@ -4880,8 +4880,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_XSize, prefix + "split_xsize", T(0.5)));//Params.
-		m_Params.push_back(ParamWithName<T>(&m_YSize, prefix + "split_ysize", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_XSize, prefix + "split_xsize", T(T(0.5))));//Params.
+		m_Params.push_back(ParamWithName<T>(&m_YSize, prefix + "split_ysize", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(true, &m_XAng, prefix + "split_xang"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_YAng, prefix + "split_yang"));
 	}
@@ -5003,10 +5003,10 @@ public:
 		string warp  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t roundx = (real_t)(int)(vIn.x >= 0 ? (vIn.x + 0.5) : (vIn.x - 0.5));\n"
+		   << "\t\treal_t roundx = (real_t)(int)(vIn.x >= 0 ? (vIn.x + T(0.5)) : (vIn.x - T(0.5)));\n"
 		   << "\t\treal_t offsetx = vIn.x - roundx;\n"
 		   << "\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetx * (1.0 - " << space << ") + roundx);\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (offsetx * (T(1.0) - " << space << ") + roundx);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + offsetx * offsetx * " << warp << ");\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
@@ -5026,7 +5026,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Space, prefix + "stripes_space", T(0.5), REAL, T(0.5), 5));
+		m_Params.push_back(ParamWithName<T>(&m_Space, prefix + "stripes_space", T(T(0.5)), REAL, T(T(0.5)), 5));
 		m_Params.push_back(ParamWithName<T>(&m_Warp,  prefix + "stripes_warp"));
 	}
 
@@ -5077,7 +5077,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t r = precalcSqrtSumSquares;\n"
 		   << "\t\treal_t a = precalcAtanyx + " << swirl << " * r;\n"
-		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * 0.5);\n"
+		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * T(0.5));\n"
 		   << "\n"
 		   << "\t\ta = a * " << compFac << " + c * " << angle << ";\n"
 		   << "\t\tr = xform->m_VariationWeights[" << varIndex << "] * (r + " << hole << ");\n"
@@ -5168,7 +5168,7 @@ public:
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * pow(precalcSumSquares, " << cn << ");\n"
 		   << "\t\tint tRand = (int)(" << rn << " * MwcNext01(mwc));\n"
 		   << "\t\treal_t a = (precalcAtanyx + M_2PI * tRand) / " << power << ";\n"
-		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * 0.5);\n"
+		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * T(0.5));\n"
 		   << "\n"
 		   << "\t\ta = a * " << cf << " + c * " << angle << ";\n"
 		   << "\t\tvOut.x = r * cos(a);\n"
@@ -5259,10 +5259,10 @@ public:
 		string swirl = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = 1.0 / Zeps(precalcSqrtSumSquares);\n"
+		   << "\t\treal_t r = T(1.0) / Zeps(precalcSqrtSumSquares);\n"
 		   << "\t\treal_t a = precalcAtanyx + " << swirl << " * r;\n"
-		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * 0.5);\n"
-		   << "\t\treal_t compFac = 1 - " << angle << " * " << count << " * M_1_PI * 0.5;\n"
+		   << "\t\treal_t c = floor((" << count << " * a + M_PI) * M_1_PI * T(0.5));\n"
+		   << "\t\treal_t compFac = 1 - " << angle << " * " << count << " * M_1_PI * T(0.5);\n"
 		   << "\n"
 		   << "\t\ta = a * compFac + c * " << angle << ";\n"
 		   << "\t\tr = xform->m_VariationWeights[" << varIndex << "] * (r + " << hole << ");\n"
@@ -5645,11 +5645,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t tansin = sin(2.0 * vIn.x);\n"
-		   << "\t\treal_t tancos = cos(2.0 * vIn.x);\n"
-		   << "\t\treal_t tansinh = sinh(2.0 * vIn.y);\n"
-		   << "\t\treal_t tancosh = cosh(2.0 * vIn.y);\n"
-		   << "\t\treal_t tanden = 1.0 / (tancos + tancosh);\n"
+		   << "\t\treal_t tansin = sin(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t tancos = cos(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t tansinh = sinh(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t tancosh = cosh(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t tanden = T(1.0) / (tancos + tancosh);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * tanden * tansin;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * tanden * tansinh;\n"
@@ -5694,7 +5694,7 @@ public:
 		   << "\t\treal_t seccos = cos(vIn.x);\n"
 		   << "\t\treal_t secsinh = sinh(vIn.y);\n"
 		   << "\t\treal_t seccosh = cosh(vIn.y);\n"
-		   << "\t\treal_t secden = 2.0 / (cos(2.0 * vIn.x) + cosh(2.0 * vIn.y));\n"
+		   << "\t\treal_t secden = T(2.0) / (cos(T(2.0) * vIn.x) + cosh(T(2.0) * vIn.y));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * secden * seccos * seccosh;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * secden * secsin * secsinh;\n"
@@ -5739,7 +5739,7 @@ public:
 		   << "\t\treal_t csccos = cos(vIn.x);\n"
 		   << "\t\treal_t cscsinh = sinh(vIn.y);\n"
 		   << "\t\treal_t csccosh = cosh(vIn.y);\n"
-		   << "\t\treal_t cscden = 2.0 / (cosh(2.0 * vIn.y) - cos(2.0 * vIn.x));\n"
+		   << "\t\treal_t cscden = T(2.0) / (cosh(T(2.0) * vIn.y) - cos(T(2.0) * vIn.x));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cscden * cscsin * csccosh;\n"
 		   << "\t\tvOut.y = -(xform->m_VariationWeights[" << varIndex << "] * cscden * csccos * cscsinh);\n"
@@ -5780,11 +5780,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t cotsin = sin(2.0 * vIn.x);\n"
-		   << "\t\treal_t cotcos = cos(2.0 * vIn.x);\n"
-		   << "\t\treal_t cotsinh = sinh(2.0 * vIn.y);\n"
-		   << "\t\treal_t cotcosh = cosh(2.0 * vIn.y);\n"
-		   << "\t\treal_t cotden = 1.0 / (cotcosh - cotcos);\n"
+		   << "\t\treal_t cotsin = sin(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t cotcos = cos(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t cotsinh = sinh(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t cotcosh = cosh(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t cotden = T(1.0) / (cotcosh - cotcos);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cotden * cotsin;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cotden * -1 * cotsinh;\n"
@@ -5911,11 +5911,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t tanhsin = sin(2.0 * vIn.y);\n"
-		   << "\t\treal_t tanhcos = cos(2.0 * vIn.y);\n"
-		   << "\t\treal_t tanhsinh = sinh(2.0 * vIn.x);\n"
-		   << "\t\treal_t tanhcosh = cosh(2.0 * vIn.x);\n"
-		   << "\t\treal_t tanhden = 1.0 / (tanhcos + tanhcosh);\n"
+		   << "\t\treal_t tanhsin = sin(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t tanhcos = cos(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t tanhsinh = sinh(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t tanhcosh = cosh(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t tanhden = T(1.0) / (tanhcos + tanhcosh);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * tanhden * tanhsinh;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * tanhden * tanhsin;\n"
@@ -5960,7 +5960,7 @@ public:
 		   << "\t\treal_t sechcos = cos(vIn.y);\n"
 		   << "\t\treal_t sechsinh = sinh(vIn.x);\n"
 		   << "\t\treal_t sechcosh = cosh(vIn.x);\n"
-		   << "\t\treal_t sechden = 2.0 / (cos(2.0 * vIn.y) + cosh(2.0 * vIn.x));\n"
+		   << "\t\treal_t sechden = T(2.0) / (cos(T(2.0) * vIn.y) + cosh(T(2.0) * vIn.x));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * sechden * sechcos * sechcosh;\n"
 		   << "\t\tvOut.y = -(xform->m_VariationWeights[" << varIndex << "] * sechden * sechsin * sechsinh);\n"
@@ -6005,7 +6005,7 @@ public:
 		   << "\t\treal_t cschcos = cos(vIn.y);\n"
 		   << "\t\treal_t cschsinh = sinh(vIn.x);\n"
 		   << "\t\treal_t cschcosh = cosh(vIn.x);\n"
-		   << "\t\treal_t cschden = 2.0 / (cosh(2.0 * vIn.x) - cos(2.0 * vIn.y));\n"
+		   << "\t\treal_t cschden = T(2.0) / (cosh(T(2.0) * vIn.x) - cos(T(2.0) * vIn.y));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cschden * cschsinh * cschcos;\n"
 		   << "\t\tvOut.y = -(xform->m_VariationWeights[" << varIndex << "] * cschden * cschcosh * cschsin);\n"
@@ -6046,11 +6046,11 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t cothsin = sin(2.0 * vIn.y);\n"
-		   << "\t\treal_t cothcos = cos(2.0 * vIn.y);\n"
-		   << "\t\treal_t cothsinh = sinh(2.0 * vIn.x);\n"
-		   << "\t\treal_t cothcosh = cosh(2.0 * vIn.x);\n"
-		   << "\t\treal_t cothden = 1.0 / (cothcosh - cothcos);\n"
+		   << "\t\treal_t cothsin = sin(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t cothcos = cos(T(2.0) * vIn.y);\n"
+		   << "\t\treal_t cothsinh = sinh(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t cothcosh = cosh(T(2.0) * vIn.x);\n"
+		   << "\t\treal_t cothden = T(1.0) / (cothcosh - cothcos);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * cothden * cothsinh;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cothden * cothsin;\n"
@@ -6101,8 +6101,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t s = sin(" << freq << " * vIn.x);\n"
 		   << "\t\treal_t t = sin(" << freq << " * vIn.y);\n"
-		   << "\t\treal_t dy = vIn.y + " << augerWeight << " * (" << scale << " * s / 2.0 + fabs(vIn.y) * s);\n"
-		   << "\t\treal_t dx = vIn.x + " << augerWeight << " * (" << scale << " * t / 2.0 + fabs(vIn.x) * t);\n"
+		   << "\t\treal_t dy = vIn.y + " << augerWeight << " * (" << scale << " * s / T(2.0) + fabs(vIn.y) * s);\n"
+		   << "\t\treal_t dx = vIn.x + " << augerWeight << " * (" << scale << " * t / T(2.0) + fabs(vIn.x) * t);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + " << symmetry << " * (dx - vIn.x));\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * dy;\n"
@@ -6127,9 +6127,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Symmetry,    prefix + "auger_sym"));
-		m_Params.push_back(ParamWithName<T>(&m_AugerWeight, prefix + "auger_weight", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_AugerWeight, prefix + "auger_weight", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Freq,        prefix + "auger_freq", 5));
-		m_Params.push_back(ParamWithName<T>(&m_Scale,       prefix + "auger_scale", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_Scale,       prefix + "auger_scale", T(T(0.1))));
 	}
 
 private:
@@ -6187,11 +6187,11 @@ public:
 		   << "\t\treal_t yy = SQR(vIn.y);\n"
 		   << "\t\treal_t frac = sqrt(yy + SQR(xmw));\n"
 		   << "\n"
-		   << "\t\tif (frac == 0.0)\n"
-		   << "\t\t	frac = 1.0;\n"
+		   << "\t\tif (frac == T(0.0))\n"
+		   << "\t\t	frac = T(1.0);\n"
 		   << "\n"
 		   << "\t\treal_t avgr = xform->m_VariationWeights[" << varIndex << "] * (" << spr << " * sqrt(sqrt(yy + SQR(xpw)) / frac));\n"
-		   << "\t\treal_t avga = (atan2(vIn.y, xmw) - atan2(vIn.y, xpw)) * 0.5;\n"
+		   << "\t\treal_t avga = (atan2(vIn.y, xmw) - atan2(vIn.y, xpw)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tvOut.x = avgr * cos(avga);\n"
 		   << "\t\tvOut.y = avgr * sin(avga);\n"

--- a/Source/Ember/Variations02.h
+++ b/Source/Ember/Variations02.h
@@ -30,7 +30,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t t = xform->m_VariationWeights[" << varIndex << "] / sqrt(precalcSumSquares + T(1.0));\n"
+		   << "\t\treal_t t = xform->m_VariationWeights[" << varIndex << "] / sqrt(precalcSumSquares + (real_t)(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * t;\n"
 		   << "\t\tvOut.y = vIn.y * t;\n"
@@ -209,8 +209,8 @@ public:
 		   << "\t\t{\n"
 		   << "\t\t	real_t vx = vIn.x;\n"
 		   << "\t\t	real_t vy = vIn.y;\n"
-		   << "\t\t	real_t cx = (floor(vx / " << bwrapsCellsize << ") + T(0.5)) * " << bwrapsCellsize << ";\n"
-		   << "\t\t	real_t cy = (floor(vy / " << bwrapsCellsize << ") + T(0.5)) * " << bwrapsCellsize << ";\n"
+		   << "\t\t	real_t cx = (floor(vx / " << bwrapsCellsize << ") + (real_t)(0.5)) * " << bwrapsCellsize << ";\n"
+		   << "\t\t	real_t cy = (floor(vy / " << bwrapsCellsize << ") + (real_t)(0.5)) * " << bwrapsCellsize << ";\n"
 		   << "\t\t	real_t lx = vx - cx;\n"
 		   << "\t\t	real_t ly = vy - cy;\n"
 		   << "\n"
@@ -497,8 +497,8 @@ public:
 		   << "\t\treal_t x = floor(vIn.x * " << invSize << ");\n"
 		   << "\t\treal_t y = floor(vIn.y * " << invSize << ");\n"
 		   << "\n"
-		   << "\t\tvOut.x = " << v << " * (x + " << blurPixelizeScale << " * (MwcNext01(mwc) - T(0.5)) + T(0.5));\n"
-		   << "\t\tvOut.y = " << v << " * (y + " << blurPixelizeScale << " * (MwcNext01(mwc) - T(0.5)) + T(0.5));\n"
+		   << "\t\tvOut.x = " << v << " * (x + " << blurPixelizeScale << " * (MwcNext01(mwc) - (real_t)(0.5)) + (real_t)(0.5));\n"
+		   << "\t\tvOut.y = " << v << " * (y + " << blurPixelizeScale << " * (MwcNext01(mwc) - (real_t)(0.5)) + (real_t)(0.5));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -517,7 +517,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_BlurPixelizeSize,  prefix + "blur_pixelize_size", T(T(0.1)), REAL, EPS));
+		m_Params.push_back(ParamWithName<T>(&m_BlurPixelizeSize,  prefix + "blur_pixelize_size", T(0.1), REAL, EPS));
 		m_Params.push_back(ParamWithName<T>(&m_BlurPixelizeScale, prefix + "blur_pixelize_scale", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_V,	      prefix + "blur_pixelize_v"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_InvSize, prefix + "blur_pixelize_inv_size"));
@@ -756,7 +756,7 @@ public:
 		   << "\t\t	if (" << bcbw << " != 0)\n"
 		   << "\t\t	{\n"
 		   << "\t\t		real_t ang = atan2(y, x);\n"
-		   << "\t\t		real_t omega = (T(0.2) * " << bcbw << " * MwcNext01(mwc)) + 1;\n"
+		   << "\t\t		real_t omega = ((real_t)(0.2) * " << bcbw << " * MwcNext01(mwc)) + 1;\n"
 		   << "\t\t		real_t px = omega * cos(ang);\n"
 		   << "\t\t		real_t py = omega * sin(ang);\n"
 		   << "\n"
@@ -892,8 +892,8 @@ public:
 		string v = "parVars[" + ToUpper(m_Params[i++].Name()) + index;//Precalcs only, no params.
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = " << v << " * (MwcNext01(mwc) - T(0.5));\n"
-		   << "\t\tvOut.y = " << v << " * (MwcNext01(mwc) - T(0.5));\n"
+		   << "\t\tvOut.x = " << v << " * (MwcNext01(mwc) - (real_t)(0.5));\n"
+		   << "\t\tvOut.y = " << v << " * (MwcNext01(mwc) - (real_t)(0.5));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -996,7 +996,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tvOut.x = vOut.y = 0;\n"
-		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
+		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - (real_t)(2.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -1151,7 +1151,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t angle = MwcNext01(mwc) * M_2PI;\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - (real_t)(2.0));\n"
 		   << "\t\treal_t angle2 = MwcNext01(mwc) * M_PI;\n"
 		   << "\t\treal_t sina = sin(angle);\n"
 		   << "\t\treal_t cosa = cos(angle);\n"
@@ -1244,7 +1244,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t r2 = precalcSumSquares + SQR(vIn.z);\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(r2 * " << c2 << " + " << c2x << " * vIn.x - " << c2y << " * vIn.y + " << c2z << " * vIn.z + T(1.0));\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(r2 * " << c2 << " + " << c2x << " * vIn.x - " << c2y << " * vIn.y + " << c2z << " * vIn.z + (real_t)(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * (vIn.x + " << cx << " * r2);\n"
 		   << "\t\tvOut.y = r * (vIn.y - " << cy << " * r2);\n"
@@ -1423,8 +1423,8 @@ public:
 		string cr   = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t roundX = (real_t)(int)(vIn.x >= 0 ? (int)(vIn.x + T(0.5)) : (int)(vIn.x - T(0.5)));\n"
-		   << "\t\treal_t roundY = (real_t)(int)(vIn.y >= 0 ? (int)(vIn.y + T(0.5)) : (int)(vIn.y - T(0.5)));\n"
+		   << "\t\treal_t roundX = (real_t)(int)(vIn.x >= 0 ? (int)(vIn.x + (real_t)(0.5)) : (int)(vIn.x - (real_t)(0.5)));\n"
+		   << "\t\treal_t roundY = (real_t)(int)(vIn.y >= 0 ? (int)(vIn.y + (real_t)(0.5)) : (int)(vIn.y - (real_t)(0.5)));\n"
 		   << "\t\treal_t offsetX = vIn.x - roundX;\n"
 		   << "\t\treal_t offsetY = vIn.y - roundY;\n"
 		   << "\n"
@@ -1486,9 +1486,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_C,     prefix + "boarders2_c", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Left,  prefix + "boarders2_left", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Right, prefix + "boarders2_right", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_C,     prefix + "boarders2_c", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Left,  prefix + "boarders2_left", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Right, prefix + "boarders2_right", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(true, &m_AbsC, prefix + "boarders2_cabs"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Cl,   prefix + "boarders2_cl"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Cr,   prefix + "boarders2_cr"));
@@ -1653,9 +1653,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "checks_x", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "checks_y", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "checks_size", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "checks_x", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "checks_y", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "checks_size", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Rnd,  prefix + "checks_rnd"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Cs,  prefix + "checks_cs"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Cx,  prefix + "checks_cx"));
@@ -1941,8 +1941,8 @@ public:
 		string vv2     = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t x = T(0.5) * vIn.x + T(0.5);\n"
-		   << "\t\treal_t y = T(0.5) * vIn.y + T(0.5);\n"
+		   << "\t\treal_t x = (real_t)(0.5) * vIn.x + (real_t)(0.5);\n"
+		   << "\t\treal_t y = (real_t)(0.5) * vIn.y + (real_t)(0.5);\n"
 		   << "\t\treal_t bx = Fabsmod(" << fr << " * x);\n"
 		   << "\t\treal_t by = Fabsmod(" << fr << " * y);\n"
 		   << "\t\treal_t oscnapx = Foscn(" << amountX << ", " << px << ");\n"
@@ -2172,7 +2172,7 @@ public:
 			   << "\t\tvOut.x = vOut.y = vOut.z = 0;\n"
 			   << "\n"
 			   << "\t\tif (MwcNext01(mwc) < " << rootFace << ")\n"
-			   << "\t\t	outPoint->m_Z = max(xform->m_VariationWeights[" << varIndex << "], T(0.0));\n"
+			   << "\t\t	outPoint->m_Z = max(xform->m_VariationWeights[" << varIndex << "], (real_t)(0.0));\n"
 			   << "\t\telse\n"
 			   << "\t\t	outPoint->m_Z = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 			   << "\t}\n";
@@ -2184,7 +2184,7 @@ public:
 			   << "\t\tvOut.y = vIn.y;\n"
 			   << "\n"
 			   << "\t\tif (MwcNext01(mwc) < " << rootFace << ")\n"
-			   << "\t\t	vOut.z = max(xform->m_VariationWeights[" << varIndex << "], T(0.0));\n"
+			   << "\t\t	vOut.z = max(xform->m_VariationWeights[" << varIndex << "], (real_t)(0.0));\n"
 			   << "\t\telse\n"
 			   << "\t\t	vOut.z = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 			   << "\t}\n";
@@ -2199,7 +2199,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_RootFace, prefix + "extrude_root_face", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_RootFace, prefix + "extrude_root_face", T(0.5)));
 	}
 
 private:
@@ -2236,7 +2236,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t a = M_2PI / (precalcSqrtSumSquares + 1);\n"
-		   << "\t\treal_t r = (precalcAtanyx * M_1_PI + 1) * T(0.5);\n"
+		   << "\t\treal_t r = (precalcAtanyx * M_1_PI + 1) * (real_t)(0.5);\n"
 		   << "\t\treal_t s = sin(a);\n"
 		   << "\t\treal_t c = cos(a);\n"
 		   << "\n"
@@ -2293,11 +2293,11 @@ public:
 		   << "\t\treal_t temp = vIn.y * " << natLog << ";\n"
 		   << "\t\treal_t snum1 = sin(temp);\n"
 		   << "\t\treal_t cnum1 = cos(temp);\n"
-		   << "\t\ttemp = (vIn.x * M_PI + vIn.y * " << natLog << ") * -T(1.0);\n"
+		   << "\t\ttemp = (vIn.x * M_PI + vIn.y * " << natLog << ") * -(real_t)(1.0);\n"
 		   << "\t\treal_t snum2 = sin(temp);\n"
 		   << "\t\treal_t cnum2 = cos(temp);\n"
 		   << "\t\treal_t eradius1 = exp(vIn.x * " << natLog << ");\n"
-		   << "\t\treal_t eradius2 = exp((vIn.x * " << natLog << " - vIn.y * M_PI) * -T(1.0));\n"
+		   << "\t\treal_t eradius2 = exp((vIn.x * " << natLog << " - vIn.y * M_PI) * -(real_t)(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (eradius1 * cnum1 - eradius2 * cnum2) * " << five << ";\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (eradius1 * snum1 - eradius2 * snum2) * " << five << ";\n"
@@ -2480,7 +2480,7 @@ public:
 		   << "\n"
 		   << "\t\tif (r > 1)\n"
 		   << "\t\t{\n"
-		   << "\t\t	if (MwcNext01(mwc) > T(0.5))\n"
+		   << "\t\t	if (MwcNext01(mwc) > (real_t)(0.5))\n"
 		   << "\t\t	{\n"
 		   << "\t\t		d = sqrt(r + vIn.x);\n"
 		   << "\t\t		vOut.x = " << v2 << " * d;\n"
@@ -2496,7 +2496,7 @@ public:
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
-		   << "\t\t	if (MwcNext01(mwc) > T(0.5))\n"
+		   << "\t\t	if (MwcNext01(mwc) > (real_t)(0.5))\n"
 		   << "\t\t	{\n"
 		   << "\t\t		d = sqrt(r + vIn.x);\n"
 		   << "\t\t		vOut.x = -(" << v2 << " * d);\n"
@@ -4279,12 +4279,12 @@ public:
 		   << "\t\treal_t x2cx = " << c2x << " * vIn.x;\n"
 		   << "\t\treal_t y2cy = " << c2y << " * vIn.y;\n"
 		   << "\t\treal_t z2cz = " << c2z << " * vIn.z;\n"
-		   << "\t\treal_t val = Zeps(" << c2 << " * r2 - x2cx - y2cy - z2cz + T(1.0));\n"
+		   << "\t\treal_t val = Zeps(" << c2 << " * r2 - x2cx - y2cy - z2cz + (real_t)(1.0));\n"
 		   << "\t\treal_t d = xform->m_VariationWeights[" << varIndex << "] / val;\n"
 		   << "\n"
-		   << "\t\tvOut.x = d * (vIn.x * " << s2x << " + " << cx << " * (y2cy + z2cz - r2 - T(1.0)));\n"
-		   << "\t\tvOut.y = d * (vIn.y * " << s2y << " + " << cy << " * (x2cx + z2cz - r2 - T(1.0)));\n"
-		   << "\t\tvOut.z = d * (vIn.z * " << s2z << " + " << cz << " * (y2cy + x2cx - r2 - T(1.0)));\n"
+		   << "\t\tvOut.x = d * (vIn.x * " << s2x << " + " << cx << " * (y2cy + z2cz - r2 - (real_t)(1.0)));\n"
+		   << "\t\tvOut.y = d * (vIn.y * " << s2y << " + " << cy << " * (x2cx + z2cz - r2 - (real_t)(1.0)));\n"
+		   << "\t\tvOut.z = d * (vIn.z * " << s2z << " + " << cz << " * (y2cy + x2cx - r2 - (real_t)(1.0)));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -4708,7 +4708,7 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Frequency, prefix + "ripple_frequency", 2));
 		m_Params.push_back(ParamWithName<T>(&m_Velocity,  prefix + "ripple_velocity", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Amplitude, prefix + "ripple_amplitude", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Amplitude, prefix + "ripple_amplitude", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_CenterX,   prefix + "ripple_centerx"));
 		m_Params.push_back(ParamWithName<T>(&m_CenterY,   prefix + "ripple_centery"));
 		m_Params.push_back(ParamWithName<T>(&m_Phase,     prefix + "ripple_phase"));
@@ -4784,8 +4784,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t c0 = " << ax << " / (1 + exp(" << sx << " * vIn.x));\n"
 		   << "\t\treal_t c1 = " << ay << " / (1 + exp(" << sy << " * vIn.y));\n"
-		   << "\t\treal_t x = (2 * (c0 - T(0.5)));\n"
-		   << "\t\treal_t y = (2 * (c1 - T(0.5)));\n"
+		   << "\t\treal_t x = (2 * (c0 - (real_t)(0.5)));\n"
+		   << "\t\treal_t y = (2 * (c1 - (real_t)(0.5)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = " << vv << " * x;\n"
 		   << "\t\tvOut.y = " << vv << " * y;\n"
@@ -4935,8 +4935,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_AmpX,  prefix + "sinusgrid_ampx", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_AmpY,  prefix + "sinusgrid_ampy", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_AmpX,  prefix + "sinusgrid_ampx", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_AmpY,  prefix + "sinusgrid_ampy", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_FreqX, prefix + "sinusgrid_freqx", 1));
 		m_Params.push_back(ParamWithName<T>(&m_FreqY, prefix + "sinusgrid_freqy", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Fx, prefix + "sinusgrid_fx"));//Precalc.
@@ -5002,8 +5002,8 @@ public:
 		string distort = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t x = vIn.x * xform->m_VariationWeights[" << varIndex << "] * T(0.05);\n"
-		   << "\t\treal_t y = vIn.y * xform->m_VariationWeights[" << varIndex << "] * T(0.05);\n"
+		   << "\t\treal_t x = vIn.x * xform->m_VariationWeights[" << varIndex << "] * (real_t)(0.05);\n"
+		   << "\t\treal_t y = vIn.y * xform->m_VariationWeights[" << varIndex << "] * (real_t)(0.05);\n"
 		   << "\t\treal_t x2 = SQR(x);\n"
 		   << "\t\treal_t y2 = SQR(y);\n"
 		   << "\t\treal_t xPlusy = x + y;\n"
@@ -5202,8 +5202,8 @@ public:
 		   << "\t\treal_t yn = r * sina;\n"
 		   << "\t\treal_t siny = sin(" << freqX << " * yn);\n"
 		   << "\t\treal_t sinx = sin(" << freqY << " * xn);\n"
-		   << "\t\treal_t dx = xn + T(0.5) * (" << scaleX << " * siny + fabs(xn) * " << incX << " * siny);\n"
-		   << "\t\treal_t dy = yn + T(0.5) * (" << scaleY << " * sinx + fabs(yn) * " << incY << " * sinx);\n"
+		   << "\t\treal_t dx = xn + (real_t)(0.5) * (" << scaleX << " * siny + fabs(xn) * " << incX << " * siny);\n"
+		   << "\t\treal_t dy = yn + (real_t)(0.5) * (" << scaleY << " * sinx + fabs(yn) * " << incY << " * sinx);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * dx;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * dy;\n"
@@ -5418,7 +5418,7 @@ public:
 		   << "\t\treal_t dot02 = " << a << " * vIn.x + " << b << " * vIn.y;\n"
 		   << "\t\treal_t dot11 = SQR(" << c << ") + SQR(" << d << ");\n"
 		   << "\t\treal_t dot12 = " << c << " * vIn.x + " << d << " * vIn.y;\n"
-		   << "\t\treal_t invDenom = T(1.0) / (dot00 * dot11 - dot01 * dot01);\n"
+		   << "\t\treal_t invDenom = (real_t)(1.0) / (dot00 * dot11 - dot01 * dot01);\n"
 		   << "\t\treal_t u = (dot11 * dot02 - dot01 * dot12) * invDenom;\n"
 		   << "\t\treal_t v = (dot00 * dot12 - dot01 * dot02) * invDenom;\n"
 		   << "\t\treal_t um = sqrt(SQR(u) + SQR(vIn.x)) * Sign(u);\n"
@@ -5531,8 +5531,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * sin(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cos(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * sin(vIn.x) * (cosh(vIn.y) + (real_t)(1.0)) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cos(vIn.x) * (cosh(vIn.y) + (real_t)(1.0)) * Sqr(sin(vIn.x));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -5568,8 +5568,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t d = xform->m_VariationWeights[" << varIndex << "] / precalcSumSquares;\n"
 		   << "\n"
-		   << "\t\tvOut.x = d * sin(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
-		   << "\t\tvOut.y = d * cos(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.x = d * sin(vIn.x) * (cosh(vIn.y) + (real_t)(1.0)) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.y = d * cos(vIn.x) * (cosh(vIn.y) + (real_t)(1.0)) * Sqr(sin(vIn.x));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 

--- a/Source/Ember/Variations02.h
+++ b/Source/Ember/Variations02.h
@@ -30,7 +30,7 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t t = xform->m_VariationWeights[" << varIndex << "] / sqrt(precalcSumSquares + 1.0);\n"
+		   << "\t\treal_t t = xform->m_VariationWeights[" << varIndex << "] / sqrt(precalcSumSquares + T(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * t;\n"
 		   << "\t\tvOut.y = vIn.y * t;\n"
@@ -209,8 +209,8 @@ public:
 		   << "\t\t{\n"
 		   << "\t\t	real_t vx = vIn.x;\n"
 		   << "\t\t	real_t vy = vIn.y;\n"
-		   << "\t\t	real_t cx = (floor(vx / " << bwrapsCellsize << ") + 0.5) * " << bwrapsCellsize << ";\n"
-		   << "\t\t	real_t cy = (floor(vy / " << bwrapsCellsize << ") + 0.5) * " << bwrapsCellsize << ";\n"
+		   << "\t\t	real_t cx = (floor(vx / " << bwrapsCellsize << ") + T(0.5)) * " << bwrapsCellsize << ";\n"
+		   << "\t\t	real_t cy = (floor(vy / " << bwrapsCellsize << ") + T(0.5)) * " << bwrapsCellsize << ";\n"
 		   << "\t\t	real_t lx = vx - cx;\n"
 		   << "\t\t	real_t ly = vy - cy;\n"
 		   << "\n"
@@ -497,8 +497,8 @@ public:
 		   << "\t\treal_t x = floor(vIn.x * " << invSize << ");\n"
 		   << "\t\treal_t y = floor(vIn.y * " << invSize << ");\n"
 		   << "\n"
-		   << "\t\tvOut.x = " << v << " * (x + " << blurPixelizeScale << " * (MwcNext01(mwc) - 0.5) + 0.5);\n"
-		   << "\t\tvOut.y = " << v << " * (y + " << blurPixelizeScale << " * (MwcNext01(mwc) - 0.5) + 0.5);\n"
+		   << "\t\tvOut.x = " << v << " * (x + " << blurPixelizeScale << " * (MwcNext01(mwc) - T(0.5)) + T(0.5));\n"
+		   << "\t\tvOut.y = " << v << " * (y + " << blurPixelizeScale << " * (MwcNext01(mwc) - T(0.5)) + T(0.5));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -517,7 +517,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_BlurPixelizeSize,  prefix + "blur_pixelize_size", T(0.1), REAL, EPS));
+		m_Params.push_back(ParamWithName<T>(&m_BlurPixelizeSize,  prefix + "blur_pixelize_size", T(T(0.1)), REAL, EPS));
 		m_Params.push_back(ParamWithName<T>(&m_BlurPixelizeScale, prefix + "blur_pixelize_scale", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_V,	      prefix + "blur_pixelize_v"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_InvSize, prefix + "blur_pixelize_inv_size"));
@@ -756,7 +756,7 @@ public:
 		   << "\t\t	if (" << bcbw << " != 0)\n"
 		   << "\t\t	{\n"
 		   << "\t\t		real_t ang = atan2(y, x);\n"
-		   << "\t\t		real_t omega = (0.2 * " << bcbw << " * MwcNext01(mwc)) + 1;\n"
+		   << "\t\t		real_t omega = (T(0.2) * " << bcbw << " * MwcNext01(mwc)) + 1;\n"
 		   << "\t\t		real_t px = omega * cos(ang);\n"
 		   << "\t\t		real_t py = omega * sin(ang);\n"
 		   << "\n"
@@ -892,8 +892,8 @@ public:
 		string v = "parVars[" + ToUpper(m_Params[i++].Name()) + index;//Precalcs only, no params.
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = " << v << " * (MwcNext01(mwc) - 0.5);\n"
-		   << "\t\tvOut.y = " << v << " * (MwcNext01(mwc) - 0.5);\n"
+		   << "\t\tvOut.x = " << v << " * (MwcNext01(mwc) - T(0.5));\n"
+		   << "\t\tvOut.y = " << v << " * (MwcNext01(mwc) - T(0.5));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -996,7 +996,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tvOut.x = vOut.y = 0;\n"
-		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - 2.0);\n"
+		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -1151,7 +1151,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t angle = MwcNext01(mwc) * M_2PI;\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - 2.0);\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) + MwcNext01(mwc) - T(2.0));\n"
 		   << "\t\treal_t angle2 = MwcNext01(mwc) * M_PI;\n"
 		   << "\t\treal_t sina = sin(angle);\n"
 		   << "\t\treal_t cosa = cos(angle);\n"
@@ -1244,7 +1244,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t r2 = precalcSumSquares + SQR(vIn.z);\n"
-		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(r2 * " << c2 << " + " << c2x << " * vIn.x - " << c2y << " * vIn.y + " << c2z << " * vIn.z + 1.0);\n"
+		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / Zeps(r2 * " << c2 << " + " << c2x << " * vIn.x - " << c2y << " * vIn.y + " << c2z << " * vIn.z + T(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = r * (vIn.x + " << cx << " * r2);\n"
 		   << "\t\tvOut.y = r * (vIn.y - " << cy << " * r2);\n"
@@ -1423,8 +1423,8 @@ public:
 		string cr   = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t roundX = (real_t)(int)(vIn.x >= 0 ? (int)(vIn.x + 0.5) : (int)(vIn.x - 0.5));\n"
-		   << "\t\treal_t roundY = (real_t)(int)(vIn.y >= 0 ? (int)(vIn.y + 0.5) : (int)(vIn.y - 0.5));\n"
+		   << "\t\treal_t roundX = (real_t)(int)(vIn.x >= 0 ? (int)(vIn.x + T(0.5)) : (int)(vIn.x - T(0.5)));\n"
+		   << "\t\treal_t roundY = (real_t)(int)(vIn.y >= 0 ? (int)(vIn.y + T(0.5)) : (int)(vIn.y - T(0.5)));\n"
 		   << "\t\treal_t offsetX = vIn.x - roundX;\n"
 		   << "\t\treal_t offsetY = vIn.y - roundY;\n"
 		   << "\n"
@@ -1486,9 +1486,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_C,     prefix + "boarders2_c", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Left,  prefix + "boarders2_left", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Right, prefix + "boarders2_right", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_C,     prefix + "boarders2_c", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Left,  prefix + "boarders2_left", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Right, prefix + "boarders2_right", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(true, &m_AbsC, prefix + "boarders2_cabs"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Cl,   prefix + "boarders2_cl"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Cr,   prefix + "boarders2_cr"));
@@ -1653,9 +1653,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "checks_x", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "checks_y", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "checks_size", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "checks_x", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "checks_y", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "checks_size", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Rnd,  prefix + "checks_rnd"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Cs,  prefix + "checks_cs"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Cx,  prefix + "checks_cx"));
@@ -1941,8 +1941,8 @@ public:
 		string vv2     = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t x = 0.5 * vIn.x + 0.5;\n"
-		   << "\t\treal_t y = 0.5 * vIn.y + 0.5;\n"
+		   << "\t\treal_t x = T(0.5) * vIn.x + T(0.5);\n"
+		   << "\t\treal_t y = T(0.5) * vIn.y + T(0.5);\n"
 		   << "\t\treal_t bx = Fabsmod(" << fr << " * x);\n"
 		   << "\t\treal_t by = Fabsmod(" << fr << " * y);\n"
 		   << "\t\treal_t oscnapx = Foscn(" << amountX << ", " << px << ");\n"
@@ -2172,7 +2172,7 @@ public:
 			   << "\t\tvOut.x = vOut.y = vOut.z = 0;\n"
 			   << "\n"
 			   << "\t\tif (MwcNext01(mwc) < " << rootFace << ")\n"
-			   << "\t\t	outPoint->m_Z = max(xform->m_VariationWeights[" << varIndex << "], 0.0);\n"
+			   << "\t\t	outPoint->m_Z = max(xform->m_VariationWeights[" << varIndex << "], T(0.0));\n"
 			   << "\t\telse\n"
 			   << "\t\t	outPoint->m_Z = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 			   << "\t}\n";
@@ -2184,7 +2184,7 @@ public:
 			   << "\t\tvOut.y = vIn.y;\n"
 			   << "\n"
 			   << "\t\tif (MwcNext01(mwc) < " << rootFace << ")\n"
-			   << "\t\t	vOut.z = max(xform->m_VariationWeights[" << varIndex << "], 0.0);\n"
+			   << "\t\t	vOut.z = max(xform->m_VariationWeights[" << varIndex << "], T(0.0));\n"
 			   << "\t\telse\n"
 			   << "\t\t	vOut.z = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 			   << "\t}\n";
@@ -2199,7 +2199,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_RootFace, prefix + "extrude_root_face", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_RootFace, prefix + "extrude_root_face", T(T(0.5))));
 	}
 
 private:
@@ -2236,7 +2236,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t a = M_2PI / (precalcSqrtSumSquares + 1);\n"
-		   << "\t\treal_t r = (precalcAtanyx * M_1_PI + 1) * 0.5;\n"
+		   << "\t\treal_t r = (precalcAtanyx * M_1_PI + 1) * T(0.5);\n"
 		   << "\t\treal_t s = sin(a);\n"
 		   << "\t\treal_t c = cos(a);\n"
 		   << "\n"
@@ -2293,11 +2293,11 @@ public:
 		   << "\t\treal_t temp = vIn.y * " << natLog << ";\n"
 		   << "\t\treal_t snum1 = sin(temp);\n"
 		   << "\t\treal_t cnum1 = cos(temp);\n"
-		   << "\t\ttemp = (vIn.x * M_PI + vIn.y * " << natLog << ") * -1.0;\n"
+		   << "\t\ttemp = (vIn.x * M_PI + vIn.y * " << natLog << ") * -T(1.0);\n"
 		   << "\t\treal_t snum2 = sin(temp);\n"
 		   << "\t\treal_t cnum2 = cos(temp);\n"
 		   << "\t\treal_t eradius1 = exp(vIn.x * " << natLog << ");\n"
-		   << "\t\treal_t eradius2 = exp((vIn.x * " << natLog << " - vIn.y * M_PI) * -1.0);\n"
+		   << "\t\treal_t eradius2 = exp((vIn.x * " << natLog << " - vIn.y * M_PI) * -T(1.0));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (eradius1 * cnum1 - eradius2 * cnum2) * " << five << ";\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (eradius1 * snum1 - eradius2 * snum2) * " << five << ";\n"
@@ -2480,7 +2480,7 @@ public:
 		   << "\n"
 		   << "\t\tif (r > 1)\n"
 		   << "\t\t{\n"
-		   << "\t\t	if (MwcNext01(mwc) > 0.5)\n"
+		   << "\t\t	if (MwcNext01(mwc) > T(0.5))\n"
 		   << "\t\t	{\n"
 		   << "\t\t		d = sqrt(r + vIn.x);\n"
 		   << "\t\t		vOut.x = " << v2 << " * d;\n"
@@ -2496,7 +2496,7 @@ public:
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
-		   << "\t\t	if (MwcNext01(mwc) > 0.5)\n"
+		   << "\t\t	if (MwcNext01(mwc) > T(0.5))\n"
 		   << "\t\t	{\n"
 		   << "\t\t		d = sqrt(r + vIn.x);\n"
 		   << "\t\t		vOut.x = -(" << v2 << " * d);\n"
@@ -4279,12 +4279,12 @@ public:
 		   << "\t\treal_t x2cx = " << c2x << " * vIn.x;\n"
 		   << "\t\treal_t y2cy = " << c2y << " * vIn.y;\n"
 		   << "\t\treal_t z2cz = " << c2z << " * vIn.z;\n"
-		   << "\t\treal_t val = Zeps(" << c2 << " * r2 - x2cx - y2cy - z2cz + 1.0);\n"
+		   << "\t\treal_t val = Zeps(" << c2 << " * r2 - x2cx - y2cy - z2cz + T(1.0));\n"
 		   << "\t\treal_t d = xform->m_VariationWeights[" << varIndex << "] / val;\n"
 		   << "\n"
-		   << "\t\tvOut.x = d * (vIn.x * " << s2x << " + " << cx << " * (y2cy + z2cz - r2 - 1.0));\n"
-		   << "\t\tvOut.y = d * (vIn.y * " << s2y << " + " << cy << " * (x2cx + z2cz - r2 - 1.0));\n"
-		   << "\t\tvOut.z = d * (vIn.z * " << s2z << " + " << cz << " * (y2cy + x2cx - r2 - 1.0));\n"
+		   << "\t\tvOut.x = d * (vIn.x * " << s2x << " + " << cx << " * (y2cy + z2cz - r2 - T(1.0)));\n"
+		   << "\t\tvOut.y = d * (vIn.y * " << s2y << " + " << cy << " * (x2cx + z2cz - r2 - T(1.0)));\n"
+		   << "\t\tvOut.z = d * (vIn.z * " << s2z << " + " << cz << " * (y2cy + x2cx - r2 - T(1.0)));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -4708,7 +4708,7 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Frequency, prefix + "ripple_frequency", 2));
 		m_Params.push_back(ParamWithName<T>(&m_Velocity,  prefix + "ripple_velocity", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Amplitude, prefix + "ripple_amplitude", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Amplitude, prefix + "ripple_amplitude", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_CenterX,   prefix + "ripple_centerx"));
 		m_Params.push_back(ParamWithName<T>(&m_CenterY,   prefix + "ripple_centery"));
 		m_Params.push_back(ParamWithName<T>(&m_Phase,     prefix + "ripple_phase"));
@@ -4784,8 +4784,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t c0 = " << ax << " / (1 + exp(" << sx << " * vIn.x));\n"
 		   << "\t\treal_t c1 = " << ay << " / (1 + exp(" << sy << " * vIn.y));\n"
-		   << "\t\treal_t x = (2 * (c0 - 0.5));\n"
-		   << "\t\treal_t y = (2 * (c1 - 0.5));\n"
+		   << "\t\treal_t x = (2 * (c0 - T(0.5)));\n"
+		   << "\t\treal_t y = (2 * (c1 - T(0.5)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = " << vv << " * x;\n"
 		   << "\t\tvOut.y = " << vv << " * y;\n"
@@ -4935,8 +4935,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_AmpX,  prefix + "sinusgrid_ampx", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_AmpY,  prefix + "sinusgrid_ampy", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_AmpX,  prefix + "sinusgrid_ampx", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_AmpY,  prefix + "sinusgrid_ampy", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_FreqX, prefix + "sinusgrid_freqx", 1));
 		m_Params.push_back(ParamWithName<T>(&m_FreqY, prefix + "sinusgrid_freqy", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Fx, prefix + "sinusgrid_fx"));//Precalc.
@@ -5002,8 +5002,8 @@ public:
 		string distort = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t x = vIn.x * xform->m_VariationWeights[" << varIndex << "] * 0.05;\n"
-		   << "\t\treal_t y = vIn.y * xform->m_VariationWeights[" << varIndex << "] * 0.05;\n"
+		   << "\t\treal_t x = vIn.x * xform->m_VariationWeights[" << varIndex << "] * T(0.05);\n"
+		   << "\t\treal_t y = vIn.y * xform->m_VariationWeights[" << varIndex << "] * T(0.05);\n"
 		   << "\t\treal_t x2 = SQR(x);\n"
 		   << "\t\treal_t y2 = SQR(y);\n"
 		   << "\t\treal_t xPlusy = x + y;\n"
@@ -5202,8 +5202,8 @@ public:
 		   << "\t\treal_t yn = r * sina;\n"
 		   << "\t\treal_t siny = sin(" << freqX << " * yn);\n"
 		   << "\t\treal_t sinx = sin(" << freqY << " * xn);\n"
-		   << "\t\treal_t dx = xn + 0.5 * (" << scaleX << " * siny + fabs(xn) * " << incX << " * siny);\n"
-		   << "\t\treal_t dy = yn + 0.5 * (" << scaleY << " * sinx + fabs(yn) * " << incY << " * sinx);\n"
+		   << "\t\treal_t dx = xn + T(0.5) * (" << scaleX << " * siny + fabs(xn) * " << incX << " * siny);\n"
+		   << "\t\treal_t dy = yn + T(0.5) * (" << scaleY << " * sinx + fabs(yn) * " << incY << " * sinx);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * dx;\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * dy;\n"
@@ -5418,7 +5418,7 @@ public:
 		   << "\t\treal_t dot02 = " << a << " * vIn.x + " << b << " * vIn.y;\n"
 		   << "\t\treal_t dot11 = SQR(" << c << ") + SQR(" << d << ");\n"
 		   << "\t\treal_t dot12 = " << c << " * vIn.x + " << d << " * vIn.y;\n"
-		   << "\t\treal_t invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);\n"
+		   << "\t\treal_t invDenom = T(1.0) / (dot00 * dot11 - dot01 * dot01);\n"
 		   << "\t\treal_t u = (dot11 * dot02 - dot01 * dot12) * invDenom;\n"
 		   << "\t\treal_t v = (dot00 * dot12 - dot01 * dot02) * invDenom;\n"
 		   << "\t\treal_t um = sqrt(SQR(u) + SQR(vIn.x)) * Sign(u);\n"
@@ -5531,8 +5531,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * sin(vIn.x) * (cosh(vIn.y) + 1.0) * Sqr(sin(vIn.x));\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cos(vIn.x) * (cosh(vIn.y) + 1.0) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * sin(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * cos(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -5568,8 +5568,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t d = xform->m_VariationWeights[" << varIndex << "] / precalcSumSquares;\n"
 		   << "\n"
-		   << "\t\tvOut.x = d * sin(vIn.x) * (cosh(vIn.y) + 1.0) * Sqr(sin(vIn.x));\n"
-		   << "\t\tvOut.y = d * cos(vIn.x) * (cosh(vIn.y) + 1.0) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.x = d * sin(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
+		   << "\t\tvOut.y = d * cos(vIn.x) * (cosh(vIn.y) + T(1.0)) * Sqr(sin(vIn.x));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 

--- a/Source/Ember/Variations03.h
+++ b/Source/Ember/Variations03.h
@@ -130,7 +130,7 @@ public:
 		string power       = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r2 = pow(precalcSumSquares, " << power << " * 0.5) * xform->m_VariationWeights[" << varIndex << "];\n"
+		   << "\t\treal_t r2 = pow(precalcSumSquares, " << power << " * T(0.5)) * xform->m_VariationWeights[" << varIndex << "];\n"
 		   << "\t\treal_t ran = (precalcAtanyx / Zeps(" << denominator << ") + (" << root << " * M_2PI * floor(MwcNext01(mwc) * " << denominator << ") / Zeps(" << denominator << "))) * " << numerator << ";\n"
 		   << "\n"
 		   << "\t\tvOut.x = r2 * cos(ran);\n"
@@ -202,7 +202,7 @@ public:
 		string b = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t u = sqrt(ClampGte(Zeps(" << a << ") * SQR(vIn.x) + Zeps(" << b << ") * SQR(vIn.y), 0.0));\n"
+		   << "\t\treal_t u = sqrt(ClampGte(Zeps(" << a << ") * SQR(vIn.x) + Zeps(" << b << ") * SQR(vIn.y), T(0.0)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = cos(u) * tan(vIn.x) * xform->m_VariationWeights[" << varIndex << "];\n"
 		   << "\t\tvOut.y = sin(u) * tan(vIn.y) * xform->m_VariationWeights[" << varIndex << "];\n"
@@ -528,7 +528,7 @@ public:
 		return
 			"void GlynnSim1Circle(__constant real_t* radius1, __constant real_t* thickness, __constant real_t* x1, __constant real_t* y1, uint2* mwc, real_t* x, real_t* y)\n"
 			"{\n"
-			"	real_t r = *radius1 * (*thickness + (1.0 - *thickness) * MwcNext01(mwc));\n"
+			"	real_t r = *radius1 * (*thickness + (T(1.0) - *thickness) * MwcNext01(mwc));\n"
 			"	real_t phi = M_2PI * MwcNext01(mwc);\n"
 			"	real_t sinPhi = sin(phi);\n"
 			"	real_t cosPhi = cos(phi);\n"
@@ -557,11 +557,11 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Radius,    prefix + "GlynnSim1_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Radius1,   prefix + "GlynnSim1_radius1", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_Radius1,   prefix + "GlynnSim1_radius1", T(T(0.1))));
 		m_Params.push_back(ParamWithName<T>(&m_Phi1,      prefix + "GlynnSim1_phi1"));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim1_thickness", T(0.1), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim1_contrast", T(1.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim1_pow", T(0.5), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim1_thickness", T(T(0.1)), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim1_contrast", T(T(1.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim1_pow", T(T(0.5)), REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_X1,  prefix + "GlynnSim1_x1"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Y1,  prefix + "GlynnSim1_y1"));
 	}
@@ -711,9 +711,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Radius,    prefix + "GlynnSim2_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim2_thickness", T(0.1), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim2_contrast", T(0.5), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim2_pow", T(1.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim2_thickness", T(T(0.1)), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim2_contrast", T(T(0.5)), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim2_pow", T(T(1.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Phi1,      prefix + "GlynnSim2_Phi1"));
 		m_Params.push_back(ParamWithName<T>(&m_Phi2,      prefix + "GlynnSim2_Phi2", 360));
 		m_Params.push_back(ParamWithName<T>(true, &m_Phi10, prefix + "GlynnSim2_Phi10"));//Precalc.
@@ -870,10 +870,10 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Radius,     prefix + "GlynnSim3_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness,  prefix + "GlynnSim3_thickness", T(0.1)));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness2, prefix + "GlynnSim3_thickness2", T(0.1)));
-		m_Params.push_back(ParamWithName<T>(&m_Contrast,   prefix + "GlynnSim3_contrast", T(0.5), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Pow,        prefix + "GlynnSim3_pow", T(1.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness,  prefix + "GlynnSim3_thickness", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness2, prefix + "GlynnSim3_thickness2", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_Contrast,   prefix + "GlynnSim3_contrast", T(T(0.5)), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Pow,        prefix + "GlynnSim3_pow", T(T(1.5))));
 		m_Params.push_back(ParamWithName<T>(true, &m_Radius1, prefix + "GlynnSim3_radius1"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Radius2, prefix + "GlynnSim3_radius2"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Gamma,   prefix + "GlynnSim3_Gamma"));
@@ -995,7 +995,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Power, prefix + "starblur_power", 5, INTEGER_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Range, prefix + "starblur_range", T(0.4016228317)));
+		m_Params.push_back(ParamWithName<T>(&m_Range, prefix + "starblur_range", T(T(0.4016228317))));
 		m_Params.push_back(ParamWithName<T>(true, &m_Length, prefix + "starblur_length"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Alpha,  prefix + "starblur_alpha"));
 	}
@@ -1243,7 +1243,7 @@ public:
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
 		   << "\t\t	{\n"
-		   << "\t\t		real_t rdc = xr + (MwcNext01(mwc) * 0.5 * " << scatterDist << ");\n"
+		   << "\t\t		real_t rdc = xr + (MwcNext01(mwc) * T(0.5) * " << scatterDist << ");\n"
 		   << "\n"
 		   << "\t\t		vOut.x = xform->m_VariationWeights[" << varIndex << "] * rdc * cos(precalcAtanyx);\n"
 		   << "\t\t		vOut.y = xform->m_VariationWeights[" << varIndex << "] * rdc * sin(precalcAtanyx);\n"
@@ -1351,7 +1351,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_N,     prefix + "shredrad_n", 4, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Width, prefix + "shredrad_width", T(0.5), REAL, -1, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Width, prefix + "shredrad_width", T(T(0.5)), REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Alpha, prefix + "shredrad_alpha"));//Precalc.
 	}
 
@@ -1459,7 +1459,7 @@ protected:
 		m_Params.push_back(ParamWithName<T>(&m_N,            prefix + "blob2_n", 5, INTEGER));
 		m_Params.push_back(ParamWithName<T>(&m_Radius,       prefix + "blob2_radius"));
 		m_Params.push_back(ParamWithName<T>(&m_Prescale,     prefix + "blob2_prescale", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Postscale,    prefix + "blob2_postscale", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Postscale,    prefix + "blob2_postscale", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Symmetry,     prefix + "blob2_symmetry", 0, REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(&m_Compensation, prefix + "blob2_compensation", 0, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_DeltaHelp, prefix + "blob2_deltahelp"));//Precalc.
@@ -2185,8 +2185,8 @@ public:
 		   << "\t\treal_t c1 = Zeps(SQR(vIn.x));\n"
 		   << "\t\treal_t c2 = Zeps(SQR(vIn.y));\n"
 		   << "\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * ((1.0 / d) * cos(c1) * sin(c2));\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * ((1.0 / d) * sin(c1) * sin(c2));\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * ((T(1.0) / d) * cos(c1) * sin(c2));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * ((T(1.0) / d) * sin(c1) * sin(c2));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -2370,9 +2370,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "sschecks_x", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "sschecks_y", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "sschecks_size", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "sschecks_x", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "sschecks_y", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "sschecks_size", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Rand, prefix + "sschecks_rnd"));
 		m_Params.push_back(ParamWithName<T>(true, &m_InvSize, prefix + "sschecks_inv_size"));//Precalc.
 	}
@@ -2454,7 +2454,7 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Power,    prefix + "phoenix_julia_power", 2));
 		m_Params.push_back(ParamWithName<T>(&m_Dist,     prefix + "phoenix_julia_dist", 1));
-		m_Params.push_back(ParamWithName<T>(&m_XDistort, prefix + "phoenix_julia_x_distort", T(-0.5)));//Original omitted phoenix_ prefix.
+		m_Params.push_back(ParamWithName<T>(&m_XDistort, prefix + "phoenix_julia_x_distort", T(-T(0.5))));//Original omitted phoenix_ prefix.
 		m_Params.push_back(ParamWithName<T>(&m_YDistort, prefix + "phoenix_julia_y_distort"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Cn,      prefix + "phoenix_julia_cn"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_InvN,    prefix + "phoenix_julia_invn"));
@@ -2617,7 +2617,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\tint n;\n"
 		   << "\n"
-		   << "\t\treal_t z = 4.0 * " << dist << " / " << power << ";\n"
+		   << "\t\treal_t z = T(4.0) * " << dist << " / " << power << ";\n"
 		   << "\t\treal_t r = pow(precalcSqrtSumSquares, z);\n"
 		   << "\t\treal_t alpha = precalcAtanyx * " << power << ";\n"
 		   << "\t\treal_t x = r * cos(alpha);\n"
@@ -2631,7 +2631,7 @@ public:
 		   << "\t\tx = (reU * reV + imU * imV) / radV;\n"
 		   << "\t\ty = (imU * reV - reU * imV) / radV;\n"
 		   << "\n"
-		   << "\t\tz = 1.0 / z;\n"
+		   << "\t\tz = T(1.0) / z;\n"
 		   << "\t\tr = pow(sqrt(SQR(x) + SQR(y)), z);\n"
 		   << "\t\tn = (int)floor(" << power << " * MwcNext01(mwc));\n"
 		   << "\t\talpha = (atan2(y, x) + n * M_2PI) / floor(" << power << ");\n"
@@ -2899,7 +2899,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t t = (" << max << " - " << min << ") * MwcNext01(mwc) + " << min << ";\n"
-		   << "\t\treal_t y = MwcNext01(mwc) - 0.5;\n"
+		   << "\t\treal_t y = MwcNext01(mwc) - T(0.5);\n"
 		   << "\t\treal_t x1 = sin(" << a << " * t + " << d << ");\n"
 		   << "\t\treal_t y1 = sin(" << b << " * t);\n"
 		   << "\n"
@@ -3048,7 +3048,7 @@ public:
 		   << "\t\treal_t a = precalcAtanyx;\n"
 		   << "\t\treal_t t = log(precalcSqrtSumSquares);\n"
 		   << "\n"
-		   << "\t\tif (t < 0.0)\n"
+		   << "\t\tif (t < T(0.0))\n"
 		   << "\t\t	t -= " << sizeDiv2 << ";\n"
 		   << "\n"
 		   << "\t\tt = fmod(fabs(t), " << size << ");\n"
@@ -3161,7 +3161,7 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_R,   prefix + "taurus_r",   3));
 		m_Params.push_back(ParamWithName<T>(&m_N,   prefix + "taurus_n",   5));
-		m_Params.push_back(ParamWithName<T>(&m_Inv, prefix + "taurus_inv", T(1.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Inv, prefix + "taurus_inv", T(T(1.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Sor, prefix + "taurus_sor", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_InvTimesR, prefix + "taurus_inv_times_r"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_1MinusInv, prefix + "taurus_1_minus_inv"));
@@ -3338,11 +3338,11 @@ public:
 		string dist   = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = 0.5 * (log(Sqr(vIn.x + 1.0) + SQR(vIn.y)) - log(Sqr(vIn.x - 1.0) + SQR(vIn.y)));\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + 1.0) - atan2(vIn.y, 1.0 - vIn.x);\n"
+		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y)));\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x);\n"
 		   << "\n"
 		   << "\t\tif (tau < " << radius << " && -tau < " << radius << ")\n"
-		   << "\t\t	tau = fmod(tau + " << radius << " + " << dist << " * " << radius << ", 2.0 * " << radius << ") - " << radius << ";\n"
+		   << "\t\t	tau = fmod(tau + " << radius << " + " << dist << " * " << radius << ", T(2.0) * " << radius << ") - " << radius << ";\n"
 		   << "\n"
 		   << "\t\treal_t temp = cosh(tau) - cos(sigma);\n"
 		   << "\n"
@@ -3407,8 +3407,8 @@ public:
 		string out = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = 0.5 * (log(Sqr(vIn.x + 1.0) + SQR(vIn.y)) - log(Sqr(vIn.x - 1.0) + SQR(vIn.y)));\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + 1.0) - atan2(vIn.y, 1.0 - vIn.x);\n"
+		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y)));\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x);\n"
 		   << "\n"
 		   << "\t\tsigma = sigma + tau * " << out << " + " << in << " / tau;\n"
 		   << "\n"
@@ -3482,8 +3482,8 @@ public:
 		string split  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = 0.5 * (log(Sqr(vIn.x + 1.0) + SQR(vIn.y)) - log(Sqr(vIn.x - 1.0) + SQR(vIn.y))) / " << power << " + " << move << ";\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + 1.0) - atan2(vIn.y, 1.0 - vIn.x) + " << rotate << ";\n"
+		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y))) / " << power << " + " << move << ";\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x) + " << rotate << ";\n"
 		   << "\n"
 		   << "\t\tsigma = sigma / " << power << " + M_2PI / " << power << " * floor(MwcNext01(mwc) * " << power << ");\n"
 		   << "\n"
@@ -3567,8 +3567,8 @@ public:
 		string piCn = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = 0.5 * (log(Sqr(vIn.x + 1.0) + SQR(vIn.y)) - log(Sqr(vIn.x - 1.0) + SQR(vIn.y)));\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + 1.0) - atan2(vIn.y, 1.0 - vIn.x);\n"
+		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y)));\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x);\n"
 		   << "\t\tint alt = (int)(sigma * " << cnPi << ");\n"
 		   << "\n"
 		   << "\t\tif (alt % 2 == 0)\n"
@@ -3897,13 +3897,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\t\tint alt;\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y > 0)\n"
 		   << "\t\t{\n"
@@ -4037,13 +4037,13 @@ public:
 		   << "\n"
 		   << "\t\treal_t tmp = r2 + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4135,13 +4135,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4235,13 +4235,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4332,13 +4332,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4418,12 +4418,12 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4505,13 +4505,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"

--- a/Source/Ember/Variations03.h
+++ b/Source/Ember/Variations03.h
@@ -130,7 +130,7 @@ public:
 		string power       = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r2 = pow(precalcSumSquares, " << power << " * T(0.5)) * xform->m_VariationWeights[" << varIndex << "];\n"
+		   << "\t\treal_t r2 = pow(precalcSumSquares, " << power << " * (real_t)(0.5)) * xform->m_VariationWeights[" << varIndex << "];\n"
 		   << "\t\treal_t ran = (precalcAtanyx / Zeps(" << denominator << ") + (" << root << " * M_2PI * floor(MwcNext01(mwc) * " << denominator << ") / Zeps(" << denominator << "))) * " << numerator << ";\n"
 		   << "\n"
 		   << "\t\tvOut.x = r2 * cos(ran);\n"
@@ -202,7 +202,7 @@ public:
 		string b = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t u = sqrt(ClampGte(Zeps(" << a << ") * SQR(vIn.x) + Zeps(" << b << ") * SQR(vIn.y), T(0.0)));\n"
+		   << "\t\treal_t u = sqrt(ClampGte(Zeps(" << a << ") * SQR(vIn.x) + Zeps(" << b << ") * SQR(vIn.y), (real_t)(0.0)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = cos(u) * tan(vIn.x) * xform->m_VariationWeights[" << varIndex << "];\n"
 		   << "\t\tvOut.y = sin(u) * tan(vIn.y) * xform->m_VariationWeights[" << varIndex << "];\n"
@@ -557,11 +557,11 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Radius,    prefix + "GlynnSim1_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Radius1,   prefix + "GlynnSim1_radius1", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_Radius1,   prefix + "GlynnSim1_radius1", T(0.1)));
 		m_Params.push_back(ParamWithName<T>(&m_Phi1,      prefix + "GlynnSim1_phi1"));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim1_thickness", T(T(0.1)), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim1_contrast", T(T(1.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim1_pow", T(T(0.5)), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim1_thickness", T(0.1), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim1_contrast", T(1.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim1_pow", T(0.5), REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_X1,  prefix + "GlynnSim1_x1"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Y1,  prefix + "GlynnSim1_y1"));
 	}
@@ -711,9 +711,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Radius,    prefix + "GlynnSim2_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim2_thickness", T(T(0.1)), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim2_contrast", T(T(0.5)), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim2_pow", T(T(1.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "GlynnSim2_thickness", T(0.1), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Contrast,  prefix + "GlynnSim2_contrast", T(0.5), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Pow,       prefix + "GlynnSim2_pow", T(1.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Phi1,      prefix + "GlynnSim2_Phi1"));
 		m_Params.push_back(ParamWithName<T>(&m_Phi2,      prefix + "GlynnSim2_Phi2", 360));
 		m_Params.push_back(ParamWithName<T>(true, &m_Phi10, prefix + "GlynnSim2_Phi10"));//Precalc.
@@ -870,10 +870,10 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Radius,     prefix + "GlynnSim3_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness,  prefix + "GlynnSim3_thickness", T(T(0.1))));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness2, prefix + "GlynnSim3_thickness2", T(T(0.1))));
-		m_Params.push_back(ParamWithName<T>(&m_Contrast,   prefix + "GlynnSim3_contrast", T(T(0.5)), REAL, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Pow,        prefix + "GlynnSim3_pow", T(T(1.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness,  prefix + "GlynnSim3_thickness", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness2, prefix + "GlynnSim3_thickness2", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_Contrast,   prefix + "GlynnSim3_contrast", T(0.5), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Pow,        prefix + "GlynnSim3_pow", T(1.5)));
 		m_Params.push_back(ParamWithName<T>(true, &m_Radius1, prefix + "GlynnSim3_radius1"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Radius2, prefix + "GlynnSim3_radius2"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Gamma,   prefix + "GlynnSim3_Gamma"));
@@ -995,7 +995,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Power, prefix + "starblur_power", 5, INTEGER_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Range, prefix + "starblur_range", T(T(0.4016228317))));
+		m_Params.push_back(ParamWithName<T>(&m_Range, prefix + "starblur_range", T(0.4016228317)));
 		m_Params.push_back(ParamWithName<T>(true, &m_Length, prefix + "starblur_length"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Alpha,  prefix + "starblur_alpha"));
 	}
@@ -1243,7 +1243,7 @@ public:
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
 		   << "\t\t	{\n"
-		   << "\t\t		real_t rdc = xr + (MwcNext01(mwc) * T(0.5) * " << scatterDist << ");\n"
+		   << "\t\t		real_t rdc = xr + (MwcNext01(mwc) * (real_t)(0.5) * " << scatterDist << ");\n"
 		   << "\n"
 		   << "\t\t		vOut.x = xform->m_VariationWeights[" << varIndex << "] * rdc * cos(precalcAtanyx);\n"
 		   << "\t\t		vOut.y = xform->m_VariationWeights[" << varIndex << "] * rdc * sin(precalcAtanyx);\n"
@@ -1351,7 +1351,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_N,     prefix + "shredrad_n", 4, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Width, prefix + "shredrad_width", T(T(0.5)), REAL, -1, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Width, prefix + "shredrad_width", T(0.5), REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Alpha, prefix + "shredrad_alpha"));//Precalc.
 	}
 
@@ -1459,7 +1459,7 @@ protected:
 		m_Params.push_back(ParamWithName<T>(&m_N,            prefix + "blob2_n", 5, INTEGER));
 		m_Params.push_back(ParamWithName<T>(&m_Radius,       prefix + "blob2_radius"));
 		m_Params.push_back(ParamWithName<T>(&m_Prescale,     prefix + "blob2_prescale", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Postscale,    prefix + "blob2_postscale", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Postscale,    prefix + "blob2_postscale", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Symmetry,     prefix + "blob2_symmetry", 0, REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(&m_Compensation, prefix + "blob2_compensation", 0, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_DeltaHelp, prefix + "blob2_deltahelp"));//Precalc.
@@ -2185,8 +2185,8 @@ public:
 		   << "\t\treal_t c1 = Zeps(SQR(vIn.x));\n"
 		   << "\t\treal_t c2 = Zeps(SQR(vIn.y));\n"
 		   << "\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * ((T(1.0) / d) * cos(c1) * sin(c2));\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * ((T(1.0) / d) * sin(c1) * sin(c2));\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (((real_t)(1.0) / d) * cos(c1) * sin(c2));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (((real_t)(1.0) / d) * sin(c1) * sin(c2));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -2370,9 +2370,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "sschecks_x", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "sschecks_y", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "sschecks_size", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "sschecks_x", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "sschecks_y", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Size, prefix + "sschecks_size", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Rand, prefix + "sschecks_rnd"));
 		m_Params.push_back(ParamWithName<T>(true, &m_InvSize, prefix + "sschecks_inv_size"));//Precalc.
 	}
@@ -2617,7 +2617,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\tint n;\n"
 		   << "\n"
-		   << "\t\treal_t z = T(4.0) * " << dist << " / " << power << ";\n"
+		   << "\t\treal_t z = (real_t)(4.0) * " << dist << " / " << power << ";\n"
 		   << "\t\treal_t r = pow(precalcSqrtSumSquares, z);\n"
 		   << "\t\treal_t alpha = precalcAtanyx * " << power << ";\n"
 		   << "\t\treal_t x = r * cos(alpha);\n"
@@ -2631,7 +2631,7 @@ public:
 		   << "\t\tx = (reU * reV + imU * imV) / radV;\n"
 		   << "\t\ty = (imU * reV - reU * imV) / radV;\n"
 		   << "\n"
-		   << "\t\tz = T(1.0) / z;\n"
+		   << "\t\tz = (real_t)(1.0) / z;\n"
 		   << "\t\tr = pow(sqrt(SQR(x) + SQR(y)), z);\n"
 		   << "\t\tn = (int)floor(" << power << " * MwcNext01(mwc));\n"
 		   << "\t\talpha = (atan2(y, x) + n * M_2PI) / floor(" << power << ");\n"
@@ -2899,7 +2899,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t t = (" << max << " - " << min << ") * MwcNext01(mwc) + " << min << ";\n"
-		   << "\t\treal_t y = MwcNext01(mwc) - T(0.5);\n"
+		   << "\t\treal_t y = MwcNext01(mwc) - (real_t)(0.5);\n"
 		   << "\t\treal_t x1 = sin(" << a << " * t + " << d << ");\n"
 		   << "\t\treal_t y1 = sin(" << b << " * t);\n"
 		   << "\n"
@@ -3048,7 +3048,7 @@ public:
 		   << "\t\treal_t a = precalcAtanyx;\n"
 		   << "\t\treal_t t = log(precalcSqrtSumSquares);\n"
 		   << "\n"
-		   << "\t\tif (t < T(0.0))\n"
+		   << "\t\tif (t < (real_t)(0.0))\n"
 		   << "\t\t	t -= " << sizeDiv2 << ";\n"
 		   << "\n"
 		   << "\t\tt = fmod(fabs(t), " << size << ");\n"
@@ -3161,7 +3161,7 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_R,   prefix + "taurus_r",   3));
 		m_Params.push_back(ParamWithName<T>(&m_N,   prefix + "taurus_n",   5));
-		m_Params.push_back(ParamWithName<T>(&m_Inv, prefix + "taurus_inv", T(T(1.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Inv, prefix + "taurus_inv", T(1.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Sor, prefix + "taurus_sor", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_InvTimesR, prefix + "taurus_inv_times_r"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_1MinusInv, prefix + "taurus_1_minus_inv"));
@@ -3338,11 +3338,11 @@ public:
 		string dist   = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y)));\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x);\n"
+		   << "\t\treal_t tau = (real_t)(0.5) * (log(Sqr(vIn.x + (real_t)(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - (real_t)(1.0)) + SQR(vIn.y)));\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + (real_t)(1.0)) - atan2(vIn.y, (real_t)(1.0) - vIn.x);\n"
 		   << "\n"
 		   << "\t\tif (tau < " << radius << " && -tau < " << radius << ")\n"
-		   << "\t\t	tau = fmod(tau + " << radius << " + " << dist << " * " << radius << ", T(2.0) * " << radius << ") - " << radius << ";\n"
+		   << "\t\t	tau = fmod(tau + " << radius << " + " << dist << " * " << radius << ", (real_t)(2.0) * " << radius << ") - " << radius << ";\n"
 		   << "\n"
 		   << "\t\treal_t temp = cosh(tau) - cos(sigma);\n"
 		   << "\n"
@@ -3407,8 +3407,8 @@ public:
 		string out = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y)));\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x);\n"
+		   << "\t\treal_t tau = (real_t)(0.5) * (log(Sqr(vIn.x + (real_t)(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - (real_t)(1.0)) + SQR(vIn.y)));\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + (real_t)(1.0)) - atan2(vIn.y, (real_t)(1.0) - vIn.x);\n"
 		   << "\n"
 		   << "\t\tsigma = sigma + tau * " << out << " + " << in << " / tau;\n"
 		   << "\n"
@@ -3482,8 +3482,8 @@ public:
 		string split  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y))) / " << power << " + " << move << ";\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x) + " << rotate << ";\n"
+		   << "\t\treal_t tau = (real_t)(0.5) * (log(Sqr(vIn.x + (real_t)(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - (real_t)(1.0)) + SQR(vIn.y))) / " << power << " + " << move << ";\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + (real_t)(1.0)) - atan2(vIn.y, (real_t)(1.0) - vIn.x) + " << rotate << ";\n"
 		   << "\n"
 		   << "\t\tsigma = sigma / " << power << " + M_2PI / " << power << " * floor(MwcNext01(mwc) * " << power << ");\n"
 		   << "\n"
@@ -3567,8 +3567,8 @@ public:
 		string piCn = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t tau = T(0.5) * (log(Sqr(vIn.x + T(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - T(1.0)) + SQR(vIn.y)));\n"
-		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + T(1.0)) - atan2(vIn.y, T(1.0) - vIn.x);\n"
+		   << "\t\treal_t tau = (real_t)(0.5) * (log(Sqr(vIn.x + (real_t)(1.0)) + SQR(vIn.y)) - log(Sqr(vIn.x - (real_t)(1.0)) + SQR(vIn.y)));\n"
+		   << "\t\treal_t sigma = M_PI - atan2(vIn.y, vIn.x + (real_t)(1.0)) - atan2(vIn.y, (real_t)(1.0) - vIn.x);\n"
 		   << "\t\tint alt = (int)(sigma * " << cnPi << ");\n"
 		   << "\n"
 		   << "\t\tif (alt % 2 == 0)\n"
@@ -3897,13 +3897,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\t\tint alt;\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y > 0)\n"
 		   << "\t\t{\n"
@@ -4037,13 +4037,13 @@ public:
 		   << "\n"
 		   << "\t\treal_t tmp = r2 + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4135,13 +4135,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4235,13 +4235,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4332,13 +4332,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4418,12 +4418,12 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -4505,13 +4505,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"

--- a/Source/Ember/Variations04.h
+++ b/Source/Ember/Variations04.h
@@ -51,13 +51,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -616,8 +616,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t d = Zeps(precalcSumSquares);\n"
 		   << "\n"
-		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / d) * (tanh(d) * (T(2.0) * vIn.x));\n"
-		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / d) * (cos(d)  * (T(2.0) * vIn.y));\n"
+		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / d) * (tanh(d) * ((real_t)(2.0) * vIn.x));\n"
+		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / d) * (cos(d)  * ((real_t)(2.0) * vIn.y));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -653,8 +653,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t d = Zeps(precalcSumSquares);\n"
 		   << "\n"
-		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / T(2.0)) * (tanh(d) * (T(2.0) * vIn.x));\n"
-		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / T(2.0)) * (cos(d)  * (T(2.0) * vIn.y));\n"
+		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / (real_t)(2.0)) * (tanh(d) * ((real_t)(2.0) * vIn.x));\n"
+		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / (real_t)(2.0)) * (cos(d)  * ((real_t)(2.0) * vIn.y));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -1179,8 +1179,8 @@ public:
 		   << "\t\tr = r < 0 ? 0 : r;\n"
 		   << "\t\tr *= " << s2 << ";\n"
 		   << "\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + (MwcNext01(mwc) - T(0.5)) * r);\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + (MwcNext01(mwc) - T(0.5)) * r);\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + (MwcNext01(mwc) - (real_t)(0.5)) * r);\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + (MwcNext01(mwc) - (real_t)(0.5)) * r);\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -1425,7 +1425,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tint i, j, l, k, m, m1, n, n1;\n"
-		   << "\t\treal_t r, rMin, offsetX, offsetY, x0 = T(0.0), y0 = T(0.0), x, y;\n"
+		   << "\t\treal_t r, rMin, offsetX, offsetY, x0 = (real_t)(0.0), y0 = (real_t)(0.0), x, y;\n"
 		   << "\n"
 		   << "\t\trMin = 20;\n"
 		   << "\t\tm = (int)floor(vIn.x / " << step << ");\n"
@@ -1487,8 +1487,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_K,     prefix + "Voron_K", T(T(0.99))));
-		m_Params.push_back(ParamWithName<T>(&m_Step,  prefix + "Voron_Step", T(T(0.25)), REAL_NONZERO));
+		m_Params.push_back(ParamWithName<T>(&m_K,     prefix + "Voron_K", T(0.99)));
+		m_Params.push_back(ParamWithName<T>(&m_Step,  prefix + "Voron_Step", T(0.25), REAL_NONZERO));
 		m_Params.push_back(ParamWithName<T>(&m_Num,   prefix + "Voron_Num", 1, INTEGER, 1, 25));
 		m_Params.push_back(ParamWithName<T>(&m_XSeed, prefix + "Voron_XSeed", 3, INTEGER));
 		m_Params.push_back(ParamWithName<T>(&m_YSeed, prefix + "Voron_YSeed", 7, INTEGER));
@@ -1621,8 +1621,8 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Slices,     prefix + "waffle_slices", 6, INTEGER_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_XThickness, prefix + "waffle_xthickness", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_YThickness, prefix + "waffle_ythickness", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_XThickness, prefix + "waffle_xthickness", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_YThickness, prefix + "waffle_ythickness", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Rotation,   prefix + "waffle_rotation"));
 		m_Params.push_back(ParamWithName<T>(true, &m_SinR, prefix + "waffle_sinr"));
 		m_Params.push_back(ParamWithName<T>(true, &m_CosR, prefix + "waffle_cosr"));
@@ -1661,9 +1661,9 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
-		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - (real_t)(0.5));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - (real_t)(0.5));\n"
+		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - (real_t)(0.5));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -1825,8 +1825,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Rho,       prefix + "SuperShape3D_rho", T(T(9.9))));
-		m_Params.push_back(ParamWithName<T>(&m_Phi,       prefix + "SuperShape3D_phi", T(T(2.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Rho,       prefix + "SuperShape3D_rho", T(9.9)));
+		m_Params.push_back(ParamWithName<T>(&m_Phi,       prefix + "SuperShape3D_phi", T(2.5)));
 		m_Params.push_back(ParamWithName<T>(&m_M1,        prefix + "SuperShape3D_m1", 6));
 		m_Params.push_back(ParamWithName<T>(&m_M2,        prefix + "SuperShape3D_m2", 3));
 		m_Params.push_back(ParamWithName<T>(&m_A1,        prefix + "SuperShape3D_a1", 1));
@@ -2043,7 +2043,7 @@ public:
 			<< "\n"
 			<< "\t\tconst real_t rad = sqrt(SQR(xi) + SQR(yi));\n"
 			<< "\t\tconst real_t ang = atan2(yi, xi);\n"
-			<< "\t\tconst real_t rdc = " << radius << " + (MwcNext01(mwc) * T(0.5) * " << ca << "); \n"
+			<< "\t\tconst real_t rdc = " << radius << " + (MwcNext01(mwc) * (real_t)(0.5) * " << ca << "); \n"
 			<< "\t\tconst real_t s = sin(ang);\n"
 			<< "\t\tconst real_t c = cos(ang);\n"
 			<< "\n"
@@ -2574,7 +2574,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tconst real_t zr = Hypot(vIn.z, precalcSqrtSumSquares);\n"
-		   << "\t\tconst real_t phi = acos(Clamp(vIn.z / zr, -T(1.0), T(1.0)));\n"
+		   << "\t\tconst real_t phi = acos(Clamp(vIn.z / zr, -(real_t)(1.0), (real_t)(1.0)));\n"
 		   << "\t\tconst real_t ps = sin(phi);\n"
 		   << "\t\tconst real_t pc = cos(phi);\n"
 		   << "\n"
@@ -2739,7 +2739,7 @@ public:
 		   << "\t\tconst real_t y = Powq4c(vIn.y, " << power << ");\n"
 		   << "\t\tconst real_t z = Powq4c(vIn.z, " << power << ");\n"
 		   << "\t\tconst real_t d = SQR(x) - SQR(y);\n"
-		   << "\t\tconst real_t re = Spread(" << c1 << " * x + " << c2 << " * d, " << sx << ") + T(1.0);\n"
+		   << "\t\tconst real_t re = Spread(" << c1 << " * x + " << c2 << " * d, " << sx << ") + (real_t)(1.0);\n"
 		   << "\t\tconst real_t im = Spread(" << c1 << " * y + " << c2x2 << " * x * y, " << sy << ");\n"
 		   << "\t\treal_t c = Zeps(Powq4c(SQR(re) + SQR(im), " << powerInv << "));\n"
 		   << "\n"
@@ -2748,7 +2748,7 @@ public:
 		   << "\t\tvOut.x = (x * re + y * im) * r;\n"
 		   << "\t\tvOut.y = (y * re - x * im) * r;\n"
 		   << "\t\tvOut.z = (z * xform->m_VariationWeights[" << varIndex << "]) / c;\n"
-		   << "\t\toutPoint->m_ColorX = Clamp(outPoint->m_ColorX + " << dcAdjust << " * c, T(0.0), T(1.0));\n"
+		   << "\t\toutPoint->m_ColorX = Clamp(outPoint->m_ColorX + " << dcAdjust << " * c, (real_t)(0.0), (real_t)(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -2865,7 +2865,7 @@ public:
 		   << "\t\treal_t st = sin(temp);\n"
 		   << "\t\treal_t ct = cos(temp);\n"
 		   << "\n"
-		   << "\t\ttemp = fma(" << ap << ", sin(fma(" << bp << ", r, " << cp << ")), acos(Clamp(vIn.z / r, -T(1.0), T(1.0))));\n"
+		   << "\t\ttemp = fma(" << ap << ", sin(fma(" << bp << ", r, " << cp << ")), acos(Clamp(vIn.z / r, -(real_t)(1.0), (real_t)(1.0))));\n"
 		   << "\n"
 		   << "\t\treal_t sp = sin(temp);\n"
 		   << "\t\treal_t cp = cos(temp);\n"
@@ -4056,8 +4056,8 @@ public:
 		string b = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t xx = (MwcNext01(mwc) - T(0.5)) * 2;\n"
-		   << "\t\treal_t yy = (MwcNext01(mwc) - T(0.5)) * 2;\n"
+		   << "\t\treal_t xx = (MwcNext01(mwc) - (real_t)(0.5)) * 2;\n"
+		   << "\t\treal_t yy = (MwcNext01(mwc) - (real_t)(0.5)) * 2;\n"
 		   << "\t\treal_t k = SignNz(yy);\n"
 		   << "\t\treal_t yymax = ((" << a << " * pow(fabs(xx), " << p << ") + k * " << b << " * sqrt(fabs(1 - SQR(xx)))) - " << a << ");\n"
 		   << "\n"
@@ -4088,9 +4088,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_P, prefix + "blur_heart_p", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_P, prefix + "blur_heart_p", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_A, prefix + "blur_heart_a", T(-T(0.6))));
-		m_Params.push_back(ParamWithName<T>(&m_B, prefix + "blur_heart_b", T(T(0.7))));
+		m_Params.push_back(ParamWithName<T>(&m_B, prefix + "blur_heart_b", T(0.7)));
 	}
 
 private:
@@ -4350,7 +4350,7 @@ public:
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
 		   << "\n"
-		   << "\t\tr = fabs(r0 - T(0.5)) * " << oneOverRmax << ";\n"
+		   << "\t\tr = fabs(r0 - (real_t)(0.5)) * " << oneOverRmax << ";\n"
 		   << "\n"
 		   << "\t\tif (r < 1)\n"
 		   << "\t\t{\n"
@@ -4359,11 +4359,11 @@ public:
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
-		   << "\t\t	vOut.x = T(0.0);\n"
-		   << "\t\t	vOut.y = T(0.0);\n"
+		   << "\t\t	vOut.x = (real_t)(0.0);\n"
+		   << "\t\t	vOut.y = (real_t)(0.0);\n"
 		   << "\t\t}\n"
 		   << "\n"
-		   << "\t\tr = fabs(r1 - T(0.5)) * " << oneOverRmax << ";\n"
+		   << "\t\tr = fabs(r1 - (real_t)(0.5)) * " << oneOverRmax << ";\n"
 		   << "\n"
 		   << "\t\tif (r < 1)\n"
 		   << "\t\t{\n"
@@ -4393,10 +4393,10 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Extended, prefix + "Truchet_extended",  0, INTEGER, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Exponent, prefix + "Truchet_exponent",  2, REAL_CYCLIC, T(T(0.001)), 2));
-		m_Params.push_back(ParamWithName<T>(&m_ArcWidth, prefix + "Truchet_arc_width", T(T(0.5)), REAL_CYCLIC, T(T(0.001)), 1));
+		m_Params.push_back(ParamWithName<T>(&m_Exponent, prefix + "Truchet_exponent",  2, REAL_CYCLIC, T(0.001), 2));
+		m_Params.push_back(ParamWithName<T>(&m_ArcWidth, prefix + "Truchet_arc_width", T(0.5), REAL_CYCLIC, T(0.001), 1));
 		m_Params.push_back(ParamWithName<T>(&m_Rotation, prefix + "Truchet_rotation"));
-		m_Params.push_back(ParamWithName<T>(&m_Size,     prefix + "Truchet_size", 1, REAL_CYCLIC, T(T(0.001)), 10));
+		m_Params.push_back(ParamWithName<T>(&m_Size,     prefix + "Truchet_size", 1, REAL_CYCLIC, T(0.001), 10));
 		m_Params.push_back(ParamWithName<T>(&m_Seed,     prefix + "Truchet_seed", 50));
 		m_Params.push_back(ParamWithName<T>(true, &m_OneOverEx,   prefix + "Truchet_one_over_ex"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_AbsSeed,     prefix + "Truchet_abs_seed"));
@@ -4909,7 +4909,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t arg = precalcAtanyx + fmod((real_t)MwcNext(mwc), (real_t)(1 / " << reInv << ")) * M_2PI;\n"
-		   << "\t\treal_t lnmod = " << dist << " * T(0.5) * log(precalcSumSquares);\n"
+		   << "\t\treal_t lnmod = " << dist << " * (real_t)(0.5) * log(precalcSumSquares);\n"
 		   << "\t\treal_t temp = arg * " << reInv << " + lnmod * " << im100 << ";\n"
 		   << "\t\treal_t mod2 = exp(lnmod * " << reInv << " - arg * " << im100 << ");\n"
 		   << "\n"
@@ -5024,7 +5024,7 @@ public:
 		string blobDiff  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * (T(0.5) + T(0.5) * sin(" << blobWaves << " * precalcAtanxy)));\n"
+		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * ((real_t)(0.5) + (real_t)(0.5) * sin(" << blobWaves << " * precalcAtanxy)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (precalcSina * r);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (precalcCosa * r);\n"
@@ -5119,8 +5119,8 @@ public:
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t x2 = 2 * vIn.x;\n"
 		   << "\t\treal_t y2 = 2 * vIn.y;\n"
-		   << "\t\treal_t xmax = T(0.5) * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
-		   << "\t\treal_t ymax = T(0.5) * (sqrt(tmp + y2) + sqrt(tmp - y2));\n"
+		   << "\t\treal_t xmax = (real_t)(0.5) * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
+		   << "\t\treal_t ymax = (real_t)(0.5) * (sqrt(tmp + y2) + sqrt(tmp - y2));\n"
 		   << "\t\treal_t a = vIn.x / Zeps(xmax);\n"
 		   << "\t\treal_t b = SafeSqrt(1 - SQR(a));\n"
 		   << "\n"

--- a/Source/Ember/Variations04.h
+++ b/Source/Ember/Variations04.h
@@ -51,13 +51,13 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t tmp2 = 2 * vIn.x;\n"
-		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * 0.5;\n"
+		   << "\t\treal_t xmax = (SafeSqrt(tmp + tmp2) + SafeSqrt(tmp - tmp2)) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tif (xmax < 1)\n"
 		   << "\t\t	xmax = 1;\n"
 		   << "\n"
 		   << "\t\treal_t mu = acosh(xmax);\n"
-		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -1.0, 1.0));\n"
+		   << "\t\treal_t nu = acos(Clamp(vIn.x / xmax, -T(1.0), T(1.0)));\n"
 		   << "\n"
 		   << "\t\tif (vIn.y < 0)\n"
 		   << "\t\t	nu *= -1;\n"
@@ -616,8 +616,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t d = Zeps(precalcSumSquares);\n"
 		   << "\n"
-		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / d) * (tanh(d) * (2.0 * vIn.x));\n"
-		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / d) * (cos(d)  * (2.0 * vIn.y));\n"
+		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / d) * (tanh(d) * (T(2.0) * vIn.x));\n"
+		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / d) * (cos(d)  * (T(2.0) * vIn.y));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -653,8 +653,8 @@ public:
 		ss << "\t{\n"
 		   << "\t\treal_t d = Zeps(precalcSumSquares);\n"
 		   << "\n"
-		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / 2.0) * (tanh(d) * (2.0 * vIn.x));\n"
-		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / 2.0) * (cos(d)  * (2.0 * vIn.y));\n"
+		   << "\t\tvOut.x = (xform->m_VariationWeights[" << varIndex << "] / T(2.0)) * (tanh(d) * (T(2.0) * vIn.x));\n"
+		   << "\t\tvOut.y = (xform->m_VariationWeights[" << varIndex << "] / T(2.0)) * (cos(d)  * (T(2.0) * vIn.y));\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -1179,8 +1179,8 @@ public:
 		   << "\t\tr = r < 0 ? 0 : r;\n"
 		   << "\t\tr *= " << s2 << ";\n"
 		   << "\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + (MwcNext01(mwc) - 0.5) * r);\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + (MwcNext01(mwc) - 0.5) * r);\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + (MwcNext01(mwc) - T(0.5)) * r);\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + (MwcNext01(mwc) - T(0.5)) * r);\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -1425,7 +1425,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tint i, j, l, k, m, m1, n, n1;\n"
-		   << "\t\treal_t r, rMin, offsetX, offsetY, x0 = 0.0, y0 = 0.0, x, y;\n"
+		   << "\t\treal_t r, rMin, offsetX, offsetY, x0 = T(0.0), y0 = T(0.0), x, y;\n"
 		   << "\n"
 		   << "\t\trMin = 20;\n"
 		   << "\t\tm = (int)floor(vIn.x / " << step << ");\n"
@@ -1487,8 +1487,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_K,     prefix + "Voron_K", T(0.99)));
-		m_Params.push_back(ParamWithName<T>(&m_Step,  prefix + "Voron_Step", T(0.25), REAL_NONZERO));
+		m_Params.push_back(ParamWithName<T>(&m_K,     prefix + "Voron_K", T(T(0.99))));
+		m_Params.push_back(ParamWithName<T>(&m_Step,  prefix + "Voron_Step", T(T(0.25)), REAL_NONZERO));
 		m_Params.push_back(ParamWithName<T>(&m_Num,   prefix + "Voron_Num", 1, INTEGER, 1, 25));
 		m_Params.push_back(ParamWithName<T>(&m_XSeed, prefix + "Voron_XSeed", 3, INTEGER));
 		m_Params.push_back(ParamWithName<T>(&m_YSeed, prefix + "Voron_YSeed", 7, INTEGER));
@@ -1621,8 +1621,8 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Slices,     prefix + "waffle_slices", 6, INTEGER_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_XThickness, prefix + "waffle_xthickness", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_YThickness, prefix + "waffle_ythickness", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_XThickness, prefix + "waffle_xthickness", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_YThickness, prefix + "waffle_ythickness", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Rotation,   prefix + "waffle_rotation"));
 		m_Params.push_back(ParamWithName<T>(true, &m_SinR, prefix + "waffle_sinr"));
 		m_Params.push_back(ParamWithName<T>(true, &m_CosR, prefix + "waffle_cosr"));
@@ -1661,9 +1661,9 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - 0.5);\n"
-		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - 0.5);\n"
-		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - 0.5);\n"
+		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
+		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
+		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * (MwcNext01(mwc) - T(0.5));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -1825,8 +1825,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Rho,       prefix + "SuperShape3D_rho", T(9.9)));
-		m_Params.push_back(ParamWithName<T>(&m_Phi,       prefix + "SuperShape3D_phi", T(2.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Rho,       prefix + "SuperShape3D_rho", T(T(9.9))));
+		m_Params.push_back(ParamWithName<T>(&m_Phi,       prefix + "SuperShape3D_phi", T(T(2.5))));
 		m_Params.push_back(ParamWithName<T>(&m_M1,        prefix + "SuperShape3D_m1", 6));
 		m_Params.push_back(ParamWithName<T>(&m_M2,        prefix + "SuperShape3D_m2", 3));
 		m_Params.push_back(ParamWithName<T>(&m_A1,        prefix + "SuperShape3D_a1", 1));
@@ -2043,7 +2043,7 @@ public:
 			<< "\n"
 			<< "\t\tconst real_t rad = sqrt(SQR(xi) + SQR(yi));\n"
 			<< "\t\tconst real_t ang = atan2(yi, xi);\n"
-			<< "\t\tconst real_t rdc = " << radius << " + (MwcNext01(mwc) * 0.5 * " << ca << "); \n"
+			<< "\t\tconst real_t rdc = " << radius << " + (MwcNext01(mwc) * T(0.5) * " << ca << "); \n"
 			<< "\t\tconst real_t s = sin(ang);\n"
 			<< "\t\tconst real_t c = cos(ang);\n"
 			<< "\n"
@@ -2574,7 +2574,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\tconst real_t zr = Hypot(vIn.z, precalcSqrtSumSquares);\n"
-		   << "\t\tconst real_t phi = acos(Clamp(vIn.z / zr, -1.0, 1.0));\n"
+		   << "\t\tconst real_t phi = acos(Clamp(vIn.z / zr, -T(1.0), T(1.0)));\n"
 		   << "\t\tconst real_t ps = sin(phi);\n"
 		   << "\t\tconst real_t pc = cos(phi);\n"
 		   << "\n"
@@ -2739,7 +2739,7 @@ public:
 		   << "\t\tconst real_t y = Powq4c(vIn.y, " << power << ");\n"
 		   << "\t\tconst real_t z = Powq4c(vIn.z, " << power << ");\n"
 		   << "\t\tconst real_t d = SQR(x) - SQR(y);\n"
-		   << "\t\tconst real_t re = Spread(" << c1 << " * x + " << c2 << " * d, " << sx << ") + 1.0;\n"
+		   << "\t\tconst real_t re = Spread(" << c1 << " * x + " << c2 << " * d, " << sx << ") + T(1.0);\n"
 		   << "\t\tconst real_t im = Spread(" << c1 << " * y + " << c2x2 << " * x * y, " << sy << ");\n"
 		   << "\t\treal_t c = Zeps(Powq4c(SQR(re) + SQR(im), " << powerInv << "));\n"
 		   << "\n"
@@ -2748,7 +2748,7 @@ public:
 		   << "\t\tvOut.x = (x * re + y * im) * r;\n"
 		   << "\t\tvOut.y = (y * re - x * im) * r;\n"
 		   << "\t\tvOut.z = (z * xform->m_VariationWeights[" << varIndex << "]) / c;\n"
-		   << "\t\toutPoint->m_ColorX = Clamp(outPoint->m_ColorX + " << dcAdjust << " * c, 0.0, 1.0);\n"
+		   << "\t\toutPoint->m_ColorX = Clamp(outPoint->m_ColorX + " << dcAdjust << " * c, T(0.0), T(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -2865,7 +2865,7 @@ public:
 		   << "\t\treal_t st = sin(temp);\n"
 		   << "\t\treal_t ct = cos(temp);\n"
 		   << "\n"
-		   << "\t\ttemp = fma(" << ap << ", sin(fma(" << bp << ", r, " << cp << ")), acos(Clamp(vIn.z / r, -1.0, 1.0)));\n"
+		   << "\t\ttemp = fma(" << ap << ", sin(fma(" << bp << ", r, " << cp << ")), acos(Clamp(vIn.z / r, -T(1.0), T(1.0))));\n"
 		   << "\n"
 		   << "\t\treal_t sp = sin(temp);\n"
 		   << "\t\treal_t cp = cos(temp);\n"
@@ -4056,8 +4056,8 @@ public:
 		string b = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t xx = (MwcNext01(mwc) - 0.5) * 2;\n"
-		   << "\t\treal_t yy = (MwcNext01(mwc) - 0.5) * 2;\n"
+		   << "\t\treal_t xx = (MwcNext01(mwc) - T(0.5)) * 2;\n"
+		   << "\t\treal_t yy = (MwcNext01(mwc) - T(0.5)) * 2;\n"
 		   << "\t\treal_t k = SignNz(yy);\n"
 		   << "\t\treal_t yymax = ((" << a << " * pow(fabs(xx), " << p << ") + k * " << b << " * sqrt(fabs(1 - SQR(xx)))) - " << a << ");\n"
 		   << "\n"
@@ -4088,9 +4088,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_P, prefix + "blur_heart_p", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_A, prefix + "blur_heart_a", T(-0.6)));
-		m_Params.push_back(ParamWithName<T>(&m_B, prefix + "blur_heart_b", T(0.7)));
+		m_Params.push_back(ParamWithName<T>(&m_P, prefix + "blur_heart_p", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_A, prefix + "blur_heart_a", T(-T(0.6))));
+		m_Params.push_back(ParamWithName<T>(&m_B, prefix + "blur_heart_b", T(T(0.7))));
 	}
 
 private:
@@ -4350,7 +4350,7 @@ public:
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
 		   << "\n"
-		   << "\t\tr = fabs(r0 - 0.5) * " << oneOverRmax << ";\n"
+		   << "\t\tr = fabs(r0 - T(0.5)) * " << oneOverRmax << ";\n"
 		   << "\n"
 		   << "\t\tif (r < 1)\n"
 		   << "\t\t{\n"
@@ -4359,11 +4359,11 @@ public:
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
-		   << "\t\t	vOut.x = 0.0;\n"
-		   << "\t\t	vOut.y = 0.0;\n"
+		   << "\t\t	vOut.x = T(0.0);\n"
+		   << "\t\t	vOut.y = T(0.0);\n"
 		   << "\t\t}\n"
 		   << "\n"
-		   << "\t\tr = fabs(r1 - 0.5) * " << oneOverRmax << ";\n"
+		   << "\t\tr = fabs(r1 - T(0.5)) * " << oneOverRmax << ";\n"
 		   << "\n"
 		   << "\t\tif (r < 1)\n"
 		   << "\t\t{\n"
@@ -4393,10 +4393,10 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Extended, prefix + "Truchet_extended",  0, INTEGER, 0, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Exponent, prefix + "Truchet_exponent",  2, REAL_CYCLIC, T(0.001), 2));
-		m_Params.push_back(ParamWithName<T>(&m_ArcWidth, prefix + "Truchet_arc_width", T(0.5), REAL_CYCLIC, T(0.001), 1));
+		m_Params.push_back(ParamWithName<T>(&m_Exponent, prefix + "Truchet_exponent",  2, REAL_CYCLIC, T(T(0.001)), 2));
+		m_Params.push_back(ParamWithName<T>(&m_ArcWidth, prefix + "Truchet_arc_width", T(T(0.5)), REAL_CYCLIC, T(T(0.001)), 1));
 		m_Params.push_back(ParamWithName<T>(&m_Rotation, prefix + "Truchet_rotation"));
-		m_Params.push_back(ParamWithName<T>(&m_Size,     prefix + "Truchet_size", 1, REAL_CYCLIC, T(0.001), 10));
+		m_Params.push_back(ParamWithName<T>(&m_Size,     prefix + "Truchet_size", 1, REAL_CYCLIC, T(T(0.001)), 10));
 		m_Params.push_back(ParamWithName<T>(&m_Seed,     prefix + "Truchet_seed", 50));
 		m_Params.push_back(ParamWithName<T>(true, &m_OneOverEx,   prefix + "Truchet_one_over_ex"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_AbsSeed,     prefix + "Truchet_abs_seed"));
@@ -4909,7 +4909,7 @@ public:
 
 		ss << "\t{\n"
 		   << "\t\treal_t arg = precalcAtanyx + fmod((real_t)MwcNext(mwc), (real_t)(1 / " << reInv << ")) * M_2PI;\n"
-		   << "\t\treal_t lnmod = " << dist << " * 0.5 * log(precalcSumSquares);\n"
+		   << "\t\treal_t lnmod = " << dist << " * T(0.5) * log(precalcSumSquares);\n"
 		   << "\t\treal_t temp = arg * " << reInv << " + lnmod * " << im100 << ";\n"
 		   << "\t\treal_t mod2 = exp(lnmod * " << reInv << " - arg * " << im100 << ");\n"
 		   << "\n"
@@ -5024,7 +5024,7 @@ public:
 		string blobDiff  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * (0.5 + 0.5 * sin(" << blobWaves << " * precalcAtanxy)));\n"
+		   << "\t\treal_t r = precalcSqrtSumSquares * (" << blobLow << " + " << blobDiff << " * (T(0.5) + T(0.5) * sin(" << blobWaves << " * precalcAtanxy)));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (precalcSina * r);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (precalcCosa * r);\n"
@@ -5119,8 +5119,8 @@ public:
 		   << "\t\treal_t tmp = precalcSumSquares + 1;\n"
 		   << "\t\treal_t x2 = 2 * vIn.x;\n"
 		   << "\t\treal_t y2 = 2 * vIn.y;\n"
-		   << "\t\treal_t xmax = 0.5 * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
-		   << "\t\treal_t ymax = 0.5 * (sqrt(tmp + y2) + sqrt(tmp - y2));\n"
+		   << "\t\treal_t xmax = T(0.5) * (sqrt(tmp + x2) + sqrt(tmp - x2));\n"
+		   << "\t\treal_t ymax = T(0.5) * (sqrt(tmp + y2) + sqrt(tmp - y2));\n"
 		   << "\t\treal_t a = vIn.x / Zeps(xmax);\n"
 		   << "\t\treal_t b = SafeSqrt(1 - SQR(a));\n"
 		   << "\n"

--- a/Source/Ember/Variations05.h
+++ b/Source/Ember/Variations05.h
@@ -45,7 +45,7 @@ public:
 		string z = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t t = 0.25 * (precalcSumSquares + SQR(vIn.z)) + 1;\n"
+		   << "\t\treal_t t = T(0.25) * (precalcSumSquares + SQR(vIn.z)) + 1;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / t;\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * r * " << x << ";\n"
@@ -158,12 +158,12 @@ public:
 		string seed    = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tint m = (int)floor(0.5 * vIn.x / " << sc << ");\n"
-		   << "\t\tint n = (int)floor(0.5 * vIn.y / " << sc << ");\n"
+		   << "\t\tint m = (int)floor(T(0.5) * vIn.x / " << sc << ");\n"
+		   << "\t\tint n = (int)floor(T(0.5) * vIn.y / " << sc << ");\n"
 		   << "\t\treal_t x = vIn.x - (m * 2 + 1) * " << sc << ";\n"
 		   << "\t\treal_t y = vIn.y - (n * 2 + 1) * " << sc << ";\n"
 		   << "\t\treal_t u = Zeps(Hypot(x, y));\n"
-		   << "\t\treal_t v = (0.3 + 0.7 * CircleLinearDiscreteNoise2(m + 10, n + 3)) * " << sc << ";\n"
+		   << "\t\treal_t v = (T(0.3) + T(0.7) * CircleLinearDiscreteNoise2(m + 10, n + 3)) * " << sc << ";\n"
 		   << "\t\treal_t z1 = CircleLinearDiscreteNoise2((int)(m + " << seed << "), n);\n"
 		   << "\n"
 		   << "\t\tif ((z1 < " << dens1 << ") && (u < v))\n"
@@ -230,9 +230,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Sc,      prefix + "CircleLinear_Sc", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_K,       prefix + "CircleLinear_K", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Dens1,   prefix + "CircleLinear_Dens1", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_Dens2,   prefix + "CircleLinear_Dens2", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_K,       prefix + "CircleLinear_K", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Dens1,   prefix + "CircleLinear_Dens1", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Dens2,   prefix + "CircleLinear_Dens2", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Reverse, prefix + "CircleLinear_Reverse", 1));
 		m_Params.push_back(ParamWithName<T>(&m_X,       prefix + "CircleLinear_X", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Y,       prefix + "CircleLinear_Y", 10));
@@ -320,8 +320,8 @@ public:
 		   << "\t\t{\n"
 		   << "\t\t	x = " << x << " * (1 - 2 * MwcNext01(mwc));\n"
 		   << "\t\t	y = " << y << " * (1 - 2 * MwcNext01(mwc));\n"
-		   << "\t\t	m = (int)floor(0.5 * x / " << sc << ");\n"
-		   << "\t\t	n = (int)floor(0.5 * y / " << sc << ");\n"
+		   << "\t\t	m = (int)floor(T(0.5) * x / " << sc << ");\n"
+		   << "\t\t	n = (int)floor(T(0.5) * y / " << sc << ");\n"
 		   << "\t\t	x = x - (m * 2 + 1) * " << sc << ";\n"
 		   << "\t\t	y = y - (n * 2 + 1) * " << sc << ";\n"
 		   << "\t\t	u = Hypot(x, y);\n"
@@ -329,7 +329,7 @@ public:
 		   << "\t\t	if (++iters > 10)\n"
 		   << "\t\t		break;\n"
 		   << "\t\t}\n"
-		   << "\t\twhile ((CircleRandDiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > (0.3 + 0.7 * CircleRandDiscreteNoise2(m + 10, n + 3)) * " << sc << "));\n"
+		   << "\t\twhile ((CircleRandDiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > (T(0.3) + T(0.7) * CircleRandDiscreteNoise2(m + 10, n + 3)) * " << sc << "));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (x + (m * 2 + 1) * " << sc << ");\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (y + (n * 2 + 1) * " << sc << ");\n"
@@ -361,7 +361,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Sc,   prefix + "CircleRand_Sc", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleRand_Dens", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleRand_Dens", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "CircleRand_X", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "CircleRand_Y", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Seed, prefix + "CircleRand_Seed", 0, INTEGER));
@@ -445,14 +445,14 @@ public:
 		   << "\n"
 		   << "\t\tCircleTrans1Trans(" << x << ", " << y << ", vIn.x, vIn.y, &ux, &uy);\n"
 		   << "\n"
-		   << "\t\tint m = (int)floor(0.5 * ux / " << sc << ");\n"
-		   << "\t\tint n = (int)floor(0.5 * uy / " << sc << ");\n"
+		   << "\t\tint m = (int)floor(T(0.5) * ux / " << sc << ");\n"
+		   << "\t\tint n = (int)floor(T(0.5) * uy / " << sc << ");\n"
 		   << "\n"
 		   << "\t\tx = ux - (m * 2 + 1) * " << sc << ";\n"
 		   << "\t\ty = uy - (n * 2 + 1) * " << sc << ";\n"
 		   << "\t\tu = Hypot(x, y);\n"
 		   << "\n"
-		   << "\t\tif ((CircleTrans1DiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > (0.3 + 0.7 * CircleTrans1DiscreteNoise2(m + 10, n + 3)) * " << sc << "))\n"
+		   << "\t\tif ((CircleTrans1DiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > (T(0.3) + T(0.7) * CircleTrans1DiscreteNoise2(m + 10, n + 3)) * " << sc << "))\n"
 		   << "\t\t{\n"
 		   << "\t\t	ux = ux;\n"
 		   << "\t\t	uy = uy;\n"
@@ -485,8 +485,8 @@ public:
 			"\n"
 			"void CircleTrans1Trans(real_t a, real_t b, real_t x, real_t y, real_t* x1, real_t* y1)\n"
 			"{\n"
-			"	*x1 = (x - a) * 0.5 + a;\n"
-			"	*y1 = (y - b) * 0.5 + b;\n"
+			"	*x1 = (x - a) * T(0.5) + a;\n"
+			"	*y1 = (y - b) * T(0.5) + b;\n"
 			"}\n"
 			"\n"
 			"void CircleTrans1CircleR(real_t mx, real_t my, real_t sc, real_t seed, real_t dens, real_t* ux, real_t* vy, uint2* mwc)\n"
@@ -498,10 +498,10 @@ public:
 			"	{\n"
 			"		x = fabs(mx) * (1 - 2 * MwcNext01(mwc));\n"
 			"		y = fabs(my) * (1 - 2 * MwcNext01(mwc));\n"
-			"		m = (int)floor(0.5 * x / sc);\n"
-			"		n = (int)floor(0.5 * y / sc);\n"
+			"		m = (int)floor(T(0.5) * x / sc);\n"
+			"		n = (int)floor(T(0.5) * y / sc);\n"
 			"		alpha = M_2PI * MwcNext01(mwc);\n"
-			"		u = 0.3 + 0.7 * CircleTrans1DiscreteNoise2(m + 10, n + 3);\n"
+			"		u = T(0.3) + T(0.7) * CircleTrans1DiscreteNoise2(m + 10, n + 3);\n"
 			"		x = u * cos(alpha);\n"
 			"		y = u * sin(alpha);\n"
 			"\n"
@@ -523,7 +523,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Sc,   prefix + "CircleTrans1_Sc", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleTrans1_Dens", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleTrans1_Dens", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "CircleTrans1_X", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "CircleTrans1_Y", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Seed, prefix + "CircleTrans1_Seed", 0, INTEGER));
@@ -681,7 +681,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\tint useNode = MwcNext(mwc) & 7;\n"
 		   << "\t\treal_t exnze, wynze, znxy;\n"
-		   << "\t\treal_t lattd = xform->m_VariationWeights[" << varIndex << "] * 0.5;\n"
+		   << "\t\treal_t lattd = xform->m_VariationWeights[" << varIndex << "] * T(0.5);\n"
 		   << "\t\treal_t px, py, pz;\n"
 		   << "\n"
 		   << "\t\texnze = 1 - (" << smoothStyle << " * (1 - (cos(atan2(vIn.x, vIn.z)))));\n"
@@ -690,7 +690,7 @@ public:
 		   << "\t\tif (" << smoothStyle << " > 1)\n"
 		   << "\t\t	znxy = 1 - (" << smoothStyle << " * (1 - ((exnze + wynze) / 2 * " << smoothStyle << ")));\n"
 		   << "\t\telse\n"
-		   << "\t\t	znxy = 1 - (" << smoothStyle << " * (1 - ((exnze + wynze) * 0.5)));\n";
+		   << "\t\t	znxy = 1 - (" << smoothStyle << " * (1 - ((exnze + wynze) * T(0.5))));\n";
 
 		if (m_VarType == VARTYPE_PRE)
 		{
@@ -787,7 +787,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubic3D_xpand", T(0.25)));
+		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubic3D_xpand", T(T(0.25))));
 		m_Params.push_back(ParamWithName<T>(&m_Style, prefix + "cubic3D_style"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Fill,        prefix + "cubic3D_fill"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Smooth,      prefix + "cubic3D_smooth"));
@@ -915,7 +915,7 @@ public:
 		   << "\t\t{\n"
 		   << "\t\t	exnze = cos(atan2(vIn.x, vIn.z));\n"
 		   << "\t\t	wynze = sin(atan2(vIn.y, vIn.z));\n"
-		   << "\t\t	znxy = (exnze + wynze) * 0.5;\n"
+		   << "\t\t	znxy = (exnze + wynze) * T(0.5);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
@@ -1005,7 +1005,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubicLattice_3D_xpand", T(0.2)));//Original used a prefix of cubic3D_, which is incompatible with Ember's design.
+		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubicLattice_3D_xpand", T(T(0.2))));//Original used a prefix of cubic3D_, which is incompatible with Ember's design.
 		m_Params.push_back(ParamWithName<T>(&m_Style, prefix + "cubicLattice_3D_style", 1, INTEGER, 1, 2));
 		m_Params.push_back(ParamWithName<T>(true, &m_Fill, prefix + "cubicLattice_3D_fill"));//Precalc.
 	}
@@ -1045,8 +1045,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t expx = exp(vIn.x) * 0.5;\n"
-		   << "\t\treal_t expnx = 0.25 / expx;\n"
+		   << "\t\treal_t expx = exp(vIn.x) * T(0.5);\n"
+		   << "\t\treal_t expnx = T(0.25) / expx;\n"
 		   << "\t\treal_t boot = vIn.z == 0 ? precalcAtanyx : vIn.z;\n"
 		   << "\t\treal_t tmp = xform->m_VariationWeights[" << varIndex << "] / (expx + expnx - (cos(vIn.y) * cos(boot)));\n"
 		   << "\n"
@@ -1117,8 +1117,8 @@ public:
 		   << "\t\treal_t cv = cos(vIn.y);\n"
 		   << "\t\treal_t cucv = cu * cv;\n"
 		   << "\t\treal_t sucv = su * cv;\n"
-		   << "\t\treal_t x = pow(fabs(cucv), " << xpow << ") + (cucv * " << xpow << ") + (0.25 * atOmegaX);\n"
-		   << "\t\treal_t y = pow(fabs(sucv), " << ypow << ") + (sucv * " << ypow << ") + (0.25 * atOmegaY);\n"
+		   << "\t\treal_t x = pow(fabs(cucv), " << xpow << ") + (cucv * " << xpow << ") + (T(0.25) * atOmegaX);\n"
+		   << "\t\treal_t y = pow(fabs(sucv), " << ypow << ") + (sucv * " << ypow << ") + (T(0.25) * atOmegaY);\n"
 		   << "\t\treal_t z = pow(fabs(sv), "   << zpow << ") + sv * "    << zpow << ";\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * x;\n"
@@ -1373,13 +1373,13 @@ public:
 		   << "\n"
 		   << "\t\t	vOut.x = r * vIn.x;\n"
 		   << "\t\t	vOut.y = r * vIn.y;\n"
-		   << "\t\t	vOut.z = r * efTez * 0.5;\n"
+		   << "\t\t	vOut.z = r * efTez * T(0.5);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
 		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t	vOut.z = xform->m_VariationWeights[" << varIndex << "] * efTez * 0.5;\n"
+		   << "\t\t	vOut.z = xform->m_VariationWeights[" << varIndex << "] * efTez * T(0.5);\n"
 		   << "\t\t}\n"
 		   << "\t}\n";
 
@@ -1442,7 +1442,7 @@ public:
 		string tilt  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t t = precalcSumSquares * 0.25 + 1;\n"
+		   << "\t\treal_t t = precalcSumSquares * T(0.25) + 1;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / t;\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * r * " << x << ";\n"
@@ -1510,7 +1510,7 @@ public:
 		string scale = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t avgxy = (vIn.x + vIn.y) * 0.5;\n"
+		   << "\t\treal_t avgxy = (vIn.x + vIn.y) * T(0.5);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + " << scale << " * sin(vIn.y * " << freq << "));\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + " << scale << " * sin(vIn.x * " << freq << "));\n"
@@ -1571,7 +1571,7 @@ public:
 		string thickness = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + 0.5);\n"
+		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + T(0.5));\n"
 		   << "\t\treal_t a = " << rotation << " + M_2PI * (sl + MwcNext01(mwc) * " << thickness << ") / " << slices << ";\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 		   << "\n"
@@ -1597,8 +1597,8 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Slices,    prefix + "pie3D_slices", 6, INTEGER_NONZERO, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie3D_rotation", T(0.5), REAL_CYCLIC, 0, M_2PI));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie3D_thickness", T(0.5), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie3D_rotation", T(T(0.5)), REAL_CYCLIC, 0, M_2PI));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie3D_thickness", T(T(0.5)), REAL, 0, 1));
 	}
 
 private:
@@ -1698,9 +1698,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_3D_x", T(0.1)));
-		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_3D_y", T(0.1)));
-		m_Params.push_back(ParamWithName<T>(&m_Z, prefix + "popcorn2_3D_z", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_3D_x", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_3D_y", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_Z, prefix + "popcorn2_3D_z", T(T(0.1))));
 		m_Params.push_back(ParamWithName<T>(&m_C, prefix + "popcorn2_3D_c", 3));
 		m_Params.push_back(ParamWithName<T>(true, &m_SinTanC,    prefix + "popcorn2_3D_sintanc"));
 		m_Params.push_back(ParamWithName<T>(true, &m_HalfWeight, prefix + "popcorn2_3D_half_weight"));
@@ -1863,8 +1863,8 @@ public:
 		   << "\t\tconst real_t xrng = vIn.x / " << xdist << ";\n"
 		   << "\t\tconst real_t yrng = vIn.y / " << ydist << ";\n"
 		   << "\n"
-		   << "\t\tvOut.x = " << xw << " * ((xrng - (int)xrng) * " << xwidth << " + (int)xrng + (0.5 - xpos) * " << onemx << ");\n"
-		   << "\t\tvOut.y = " << yw << " * ((yrng - (int)yrng) * " << ywidth << " + (int)yrng + (0.5 - ypos) * " << onemy << ");\n"
+		   << "\t\tvOut.x = " << xw << " * ((xrng - (int)xrng) * " << xwidth << " + (int)xrng + (T(0.5) - xpos) * " << onemx << ");\n"
+		   << "\t\tvOut.y = " << yw << " * ((yrng - (int)yrng) * " << ywidth << " + (int)yrng + (T(0.5) - ypos) * " << onemy << ");\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -1886,9 +1886,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_XDistance, prefix + "shredlin_xdistance", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_XWidth,    prefix + "shredlin_xwidth", T(0.5), REAL, -1, 1));
+		m_Params.push_back(ParamWithName<T>(&m_XWidth,    prefix + "shredlin_xwidth", T(T(0.5)), REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(&m_YDistance, prefix + "shredlin_ydistance", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_YWidth,    prefix + "shredlin_ywidth", T(0.5), REAL, -1, 1));
+		m_Params.push_back(ParamWithName<T>(&m_YWidth,    prefix + "shredlin_ywidth", T(T(0.5)), REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Xw,  prefix + "shredlin_xw"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Yw,  prefix + "shredlin_yw"));
 		m_Params.push_back(ParamWithName<T>(true, &m_1mX, prefix + "shredlin_1mx"));
@@ -1983,7 +1983,7 @@ public:
 		string py = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t b = xform->m_VariationWeights[" << varIndex << "] / (precalcSumSquares * 0.25 + 1);\n"
+		   << "\t\treal_t b = xform->m_VariationWeights[" << varIndex << "] / (precalcSumSquares * T(0.25) + 1);\n"
 		   << "\t\treal_t roundX = rint(vIn.x);\n"
 		   << "\t\treal_t roundY = rint(vIn.y);\n"
 		   << "\t\treal_t offsetX = vIn.x - roundX;\n"
@@ -1992,10 +1992,10 @@ public:
 		   << "\t\tvOut.x = vIn.x * b;\n"
 		   << "\t\tvOut.y = vIn.y * b;\n"
 		   << "\n"
-		   << "\t\tif (MwcNext01(mwc) >= 0.75)\n"
+		   << "\t\tif (MwcNext01(mwc) >= T(0.75))\n"
 		   << "\t\t{\n"
-		   << "\t\t	vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX);\n"
-		   << "\t\t	vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY);\n"
+		   << "\t\t	vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX);\n"
+		   << "\t\t	vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
@@ -2003,26 +2003,26 @@ public:
 		   << "\t\t	{\n"
 		   << "\t\t		if (offsetX >= 0)\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX + " << x << ");\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY + " << y << " * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + " << x << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + " << y << " * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX - " << y << ");\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY - " << y << " * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - " << y << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - " << y << " * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
 		   << "\t\t	{\n"
 		   << "\t\t		if (offsetY >= 0)\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY + " << y << ");\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX + offsetX / offsetY * " << y << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + " << y << ");\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + offsetX / offsetY * " << y << ");\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * 0.5 + roundY - " << y << ");\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * 0.5 + roundX - offsetX / offsetY * " << x << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - " << y << ");\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - offsetX / offsetY * " << x << ");\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
@@ -2041,8 +2041,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X,  prefix + "SplitBrdr_x",  T(0.25)));//Original used a prefix of splitb_, which is incompatible with Ember's design.
-		m_Params.push_back(ParamWithName<T>(&m_Y,  prefix + "SplitBrdr_y",  T(0.25)));
+		m_Params.push_back(ParamWithName<T>(&m_X,  prefix + "SplitBrdr_x",  T(T(0.25))));//Original used a prefix of splitb_, which is incompatible with Ember's design.
+		m_Params.push_back(ParamWithName<T>(&m_Y,  prefix + "SplitBrdr_y",  T(T(0.25))));
 		m_Params.push_back(ParamWithName<T>(&m_Px, prefix + "SplitBrdr_px"));
 		m_Params.push_back(ParamWithName<T>(&m_Py, prefix + "SplitBrdr_py"));
 	}
@@ -2181,8 +2181,8 @@ public:
 		   << "\t\tconst real_t ay = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t az = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t r = sqrt(Sqr(vIn.x - " << x0 << ") + Sqr(vIn.y - " << y0 << ") + Sqr(vIn.z - " << z0 << "));\n"
-		   << "\t\tconst real_t rc = ((" << invert << " != 0 ? max(1 - r, 0.0) : max(r, 0.0)) - " << minDist << ") * " << internalScatter << ";\n"
-		   << "\t\tconst real_t rs = max(rc, 0.0);\n"
+		   << "\t\tconst real_t rc = ((" << invert << " != 0 ? max(1 - r, T(0.0)) : max(r, T(0.0))) - " << minDist << ") * " << internalScatter << ";\n"
+		   << "\t\tconst real_t rs = max(rc, T(0.0));\n"
 		   << "\n"
 		   << "\t\treal_t sigma, phi, rad, sigmas, sigmac, phis, phic;\n"
 		   << "\t\treal_t scale, denom;\n"
@@ -2209,7 +2209,7 @@ public:
 		   << "\t\t		vOut.z = xform->m_VariationWeights[" << varIndex << "] * (rad * sigmas);\n"
 		   << "\t\t		break;\n"
 		   << "\t\t	case 2:\n"
-		   << "\t\t		scale = Clamp(rs, 0, 0.9) + 0.1;\n"
+		   << "\t\t		scale = Clamp(rs, 0, T(0.9)) + T(0.1);\n"
 		   << "\t\t		denom = 1 / scale;\n"
 		   << "\t\t		vOut.x = xform->m_VariationWeights[" << varIndex << "] * Lerp(vIn.x, floor(vIn.x * denom) + scale * ax, " << mulX << " * rs) + " << mulX << " * pow(ax, " << boxPow << ") * rs * denom;\n"
 		   << "\t\t		vOut.y = xform->m_VariationWeights[" << varIndex << "] * Lerp(vIn.y, floor(vIn.y * denom) + scale * ay, " << mulY << " * rs) + " << mulY << " * pow(ay, " << boxPow << ") * rs * denom;\n"
@@ -2233,7 +2233,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Scatter, prefix + "falloff_scatter", 1, REAL, EPS, TMAX));
-		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff_mindist", T(0.5), REAL, 0, TMAX));
+		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff_mindist", T(T(0.5)), REAL, 0, TMAX));
 		m_Params.push_back(ParamWithName<T>(&m_MulX,    prefix + "falloff_mul_x", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulY,    prefix + "falloff_mul_y", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulZ,    prefix + "falloff_mul_z", 0, REAL, 0, 1));
@@ -2361,8 +2361,8 @@ public:
 		   << "\t\tconst real_t randz = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t randc = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t distA = sqrt(Sqr(vIn.x - " << x0 << ") + Sqr(vIn.y - " << y0 << ") + Sqr(vIn.z - " << z0 << "));\n"
-		   << "\t\tconst real_t distB = " << invert << " != 0 ? max(1 - distA, 0.0) : max(distA, 0.0);\n"
-		   << "\t\tconst real_t dist = max((distB - " << minDist << ") * " << rMax<< ", 0.0);\n"
+		   << "\t\tconst real_t distB = " << invert << " != 0 ? max(1 - distA, T(0.0)) : max(distA, T(0.0));\n"
+		   << "\t\tconst real_t dist = max((distB - " << minDist << ") * " << rMax<< ", T(0.0));\n"
 		   << "\n"
 		   << "\t\tswitch ((int)" << type << ")\n"
 		   << "\t\t{\n"
@@ -2370,7 +2370,7 @@ public:
 		   << "\t\t	   vOut.x = vIn.x + " << mulX << " * randx * dist;\n"
 		   << "\t\t	   vOut.y = vIn.y + " << mulY << " * randy * dist;\n"
 		   << "\t\t	   vOut.z = vIn.z + " << mulZ << " * randz * dist;\n"
-		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, 1.0));\n"
+		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
 		   << "\t\t	   break;\n"
 		   << "\t\t   case 1:\n"
 		   << "\t\t	   if (vIn.x == 0 && vIn.y == 0 && vIn.z == 0)\n"
@@ -2393,7 +2393,7 @@ public:
 		   << "\t\t		   vOut.x = r * sigmac * phic;\n"
 		   << "\t\t		   vOut.y = r * sigmac * phis;\n"
 		   << "\t\t		   vOut.z = r * sigmas;\n"
-		   << "\t\t		   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, 1.0));\n"
+		   << "\t\t		   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
 		   << "\t\t	   }\n"
 		   << "\t\t	   break;\n"
 		   << "\t\t   case 2:\n"
@@ -2409,7 +2409,7 @@ public:
 		   << "\t\t	   vOut.x = vIn.x + " << mulX << " * rad * sigmac * phic;\n"
 		   << "\t\t	   vOut.y = vIn.y + " << mulY << " * rad * sigmac * phis;\n"
 		   << "\t\t	   vOut.z = vIn.z + " << mulZ << " * rad * sigmas;\n"
-		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, 1.0));\n"
+		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
 		   << "\t\t	   break;\n"
 		   << "\t\t	  }\n"
 		   << "\t\t}\n"
@@ -2430,7 +2430,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Scatter, prefix + "falloff2_scatter", 1, REAL, EPS, TMAX));
-		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff2_mindist", T(0.5), REAL, 0, TMAX));
+		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff2_mindist", T(T(0.5)), REAL, 0, TMAX));
 		m_Params.push_back(ParamWithName<T>(&m_MulX,    prefix + "falloff2_mul_x", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulY,    prefix + "falloff2_mul_y", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulZ,    prefix + "falloff2_mul_z", 0, REAL, 0, 1));
@@ -2584,7 +2584,7 @@ public:
 		    << "\t\t		break;\n"
 		    << "\t\t}\n"
 		    << "\n"
-		    << "\t\tconst real_t dist = max(((" << invertDist << " != 0 ? max(1 - radius, 0.0) : max(radius, 0.0)) - " << minDist << ") * " << rMax << ", 0.0);\n"
+		    << "\t\tconst real_t dist = max(((" << invertDist << " != 0 ? max(1 - radius, T(0.0)) : max(radius, T(0.0))) - " << minDist << ") * " << rMax << ", T(0.0));\n"
 		    << "\n"
 		    << "\t\tswitch ((int)" << blurType << ")\n"
 		    << "\t\t{\n"
@@ -2601,7 +2601,7 @@ public:
 		    << "\t\t		vOut.x = vIn.x + " << mulX << " * rad * sigmac * phic;\n"
 		    << "\t\t		vOut.y = vIn.y + " << mulY << " * rad * sigmac * phis;\n"
 		    << "\t\t		vOut.z = vIn.z + " << mulZ << " * rad * sigmas;\n"
-		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, 1.0));\n"
+		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
 		    << "\t\t	}\n"
 		    << "\t\t	break;\n"
 		    << "\t\tcase 1:\n"
@@ -2625,7 +2625,7 @@ public:
 		    << "\t\t		vOut.x = r * sigmac * phic;\n"
 		    << "\t\t		vOut.y = r * sigmac * phis;\n"
 		    << "\t\t		vOut.z = r * sigmas;\n"
-		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, 1.0));\n"
+		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
 		    << "\t\t	}\n"
 		    << "\t\t	break;\n"
 		    << "\t\tcase 2:\n"
@@ -2635,7 +2635,7 @@ public:
 		    << "\t\t		vOut.x = vIn.x + LogMap(" << mulX << ") * LogScale(randx) * coeff,\n"
 		    << "\t\t		vOut.y = vIn.y + LogMap(" << mulY << ") * LogScale(randy) * coeff,\n"
 		    << "\t\t		vOut.z = vIn.z + LogMap(" << mulZ << ") * LogScale(randz) * coeff,\n"
-		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + LogMap(" << mulC << ") * LogScale(randc) * coeff, 1.0));\n"
+		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + LogMap(" << mulC << ") * LogScale(randc) * coeff, T(1.0)));\n"
 		    << "\t\t	}\n"
 		    << "\t\t	break;\n"
 		    << "\t\t}\n"
@@ -2658,7 +2658,7 @@ protected:
 		m_Params.push_back(ParamWithName<T>(&m_BlurType,       prefix + "falloff3_blur_type", 0, INTEGER, 0, 3));
 		m_Params.push_back(ParamWithName<T>(&m_BlurShape,      prefix + "falloff3_blur_shape", 0, INTEGER, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_BlurStrength,   prefix + "falloff3_blur_strength", 1, REAL, EPS, TMAX));
-		m_Params.push_back(ParamWithName<T>(&m_MinDistance,    prefix + "falloff3_min_distance", T(0.5), REAL, 0, TMAX));
+		m_Params.push_back(ParamWithName<T>(&m_MinDistance,    prefix + "falloff3_min_distance", T(T(0.5)), REAL, 0, TMAX));
 		m_Params.push_back(ParamWithName<T>(&m_InvertDistance, prefix + "falloff3_invert_distance", 0, INTEGER, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulX,           prefix + "falloff3_mul_x", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulY,           prefix + "falloff3_mul_y", 1, REAL, 0, 1));
@@ -3053,7 +3053,7 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Power,  prefix + "xtrb_power", 2, INTEGER_NONZERO));
 		m_Params.push_back(ParamWithName<T>(&m_Radius, prefix + "xtrb_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Width,  prefix + "xtrb_width", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Width,  prefix + "xtrb_width", T(T(0.5))));
 		m_Params.push_back(ParamWithName<T>(&m_Dist,   prefix + "xtrb_dist", 1));
 		m_Params.push_back(ParamWithName<T>(&m_A,      prefix + "xtrb_a", 1));
 		m_Params.push_back(ParamWithName<T>(&m_B,      prefix + "xtrb_b", 1));

--- a/Source/Ember/Variations05.h
+++ b/Source/Ember/Variations05.h
@@ -45,7 +45,7 @@ public:
 		string z = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t t = T(0.25) * (precalcSumSquares + SQR(vIn.z)) + 1;\n"
+		   << "\t\treal_t t = (real_t)(0.25) * (precalcSumSquares + SQR(vIn.z)) + 1;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / t;\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * r * " << x << ";\n"
@@ -158,12 +158,12 @@ public:
 		string seed    = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tint m = (int)floor(T(0.5) * vIn.x / " << sc << ");\n"
-		   << "\t\tint n = (int)floor(T(0.5) * vIn.y / " << sc << ");\n"
+		   << "\t\tint m = (int)floor((real_t)(0.5) * vIn.x / " << sc << ");\n"
+		   << "\t\tint n = (int)floor((real_t)(0.5) * vIn.y / " << sc << ");\n"
 		   << "\t\treal_t x = vIn.x - (m * 2 + 1) * " << sc << ";\n"
 		   << "\t\treal_t y = vIn.y - (n * 2 + 1) * " << sc << ";\n"
 		   << "\t\treal_t u = Zeps(Hypot(x, y));\n"
-		   << "\t\treal_t v = (T(0.3) + T(0.7) * CircleLinearDiscreteNoise2(m + 10, n + 3)) * " << sc << ";\n"
+		   << "\t\treal_t v = ((real_t)(0.3) + (real_t)(0.7) * CircleLinearDiscreteNoise2(m + 10, n + 3)) * " << sc << ";\n"
 		   << "\t\treal_t z1 = CircleLinearDiscreteNoise2((int)(m + " << seed << "), n);\n"
 		   << "\n"
 		   << "\t\tif ((z1 < " << dens1 << ") && (u < v))\n"
@@ -230,9 +230,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Sc,      prefix + "CircleLinear_Sc", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_K,       prefix + "CircleLinear_K", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Dens1,   prefix + "CircleLinear_Dens1", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_Dens2,   prefix + "CircleLinear_Dens2", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_K,       prefix + "CircleLinear_K", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Dens1,   prefix + "CircleLinear_Dens1", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_Dens2,   prefix + "CircleLinear_Dens2", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Reverse, prefix + "CircleLinear_Reverse", 1));
 		m_Params.push_back(ParamWithName<T>(&m_X,       prefix + "CircleLinear_X", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Y,       prefix + "CircleLinear_Y", 10));
@@ -320,8 +320,8 @@ public:
 		   << "\t\t{\n"
 		   << "\t\t	x = " << x << " * (1 - 2 * MwcNext01(mwc));\n"
 		   << "\t\t	y = " << y << " * (1 - 2 * MwcNext01(mwc));\n"
-		   << "\t\t	m = (int)floor(T(0.5) * x / " << sc << ");\n"
-		   << "\t\t	n = (int)floor(T(0.5) * y / " << sc << ");\n"
+		   << "\t\t	m = (int)floor((real_t)(0.5) * x / " << sc << ");\n"
+		   << "\t\t	n = (int)floor((real_t)(0.5) * y / " << sc << ");\n"
 		   << "\t\t	x = x - (m * 2 + 1) * " << sc << ";\n"
 		   << "\t\t	y = y - (n * 2 + 1) * " << sc << ";\n"
 		   << "\t\t	u = Hypot(x, y);\n"
@@ -329,7 +329,7 @@ public:
 		   << "\t\t	if (++iters > 10)\n"
 		   << "\t\t		break;\n"
 		   << "\t\t}\n"
-		   << "\t\twhile ((CircleRandDiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > (T(0.3) + T(0.7) * CircleRandDiscreteNoise2(m + 10, n + 3)) * " << sc << "));\n"
+		   << "\t\twhile ((CircleRandDiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > ((real_t)(0.3) + (real_t)(0.7) * CircleRandDiscreteNoise2(m + 10, n + 3)) * " << sc << "));\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (x + (m * 2 + 1) * " << sc << ");\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (y + (n * 2 + 1) * " << sc << ");\n"
@@ -361,7 +361,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Sc,   prefix + "CircleRand_Sc", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleRand_Dens", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleRand_Dens", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "CircleRand_X", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "CircleRand_Y", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Seed, prefix + "CircleRand_Seed", 0, INTEGER));
@@ -445,14 +445,14 @@ public:
 		   << "\n"
 		   << "\t\tCircleTrans1Trans(" << x << ", " << y << ", vIn.x, vIn.y, &ux, &uy);\n"
 		   << "\n"
-		   << "\t\tint m = (int)floor(T(0.5) * ux / " << sc << ");\n"
-		   << "\t\tint n = (int)floor(T(0.5) * uy / " << sc << ");\n"
+		   << "\t\tint m = (int)floor((real_t)(0.5) * ux / " << sc << ");\n"
+		   << "\t\tint n = (int)floor((real_t)(0.5) * uy / " << sc << ");\n"
 		   << "\n"
 		   << "\t\tx = ux - (m * 2 + 1) * " << sc << ";\n"
 		   << "\t\ty = uy - (n * 2 + 1) * " << sc << ";\n"
 		   << "\t\tu = Hypot(x, y);\n"
 		   << "\n"
-		   << "\t\tif ((CircleTrans1DiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > (T(0.3) + T(0.7) * CircleTrans1DiscreteNoise2(m + 10, n + 3)) * " << sc << "))\n"
+		   << "\t\tif ((CircleTrans1DiscreteNoise2((int)(m + " << seed << "), n) > " << dens << ") || (u > ((real_t)(0.3) + (real_t)(0.7) * CircleTrans1DiscreteNoise2(m + 10, n + 3)) * " << sc << "))\n"
 		   << "\t\t{\n"
 		   << "\t\t	ux = ux;\n"
 		   << "\t\t	uy = uy;\n"
@@ -523,7 +523,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Sc,   prefix + "CircleTrans1_Sc", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleTrans1_Dens", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Dens, prefix + "CircleTrans1_Dens", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_X,    prefix + "CircleTrans1_X", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Y,    prefix + "CircleTrans1_Y", 10));
 		m_Params.push_back(ParamWithName<T>(&m_Seed, prefix + "CircleTrans1_Seed", 0, INTEGER));
@@ -681,7 +681,7 @@ public:
 		ss << "\t{\n"
 		   << "\t\tint useNode = MwcNext(mwc) & 7;\n"
 		   << "\t\treal_t exnze, wynze, znxy;\n"
-		   << "\t\treal_t lattd = xform->m_VariationWeights[" << varIndex << "] * T(0.5);\n"
+		   << "\t\treal_t lattd = xform->m_VariationWeights[" << varIndex << "] * (real_t)(0.5);\n"
 		   << "\t\treal_t px, py, pz;\n"
 		   << "\n"
 		   << "\t\texnze = 1 - (" << smoothStyle << " * (1 - (cos(atan2(vIn.x, vIn.z)))));\n"
@@ -690,7 +690,7 @@ public:
 		   << "\t\tif (" << smoothStyle << " > 1)\n"
 		   << "\t\t	znxy = 1 - (" << smoothStyle << " * (1 - ((exnze + wynze) / 2 * " << smoothStyle << ")));\n"
 		   << "\t\telse\n"
-		   << "\t\t	znxy = 1 - (" << smoothStyle << " * (1 - ((exnze + wynze) * T(0.5))));\n";
+		   << "\t\t	znxy = 1 - (" << smoothStyle << " * (1 - ((exnze + wynze) * (real_t)(0.5))));\n";
 
 		if (m_VarType == VARTYPE_PRE)
 		{
@@ -787,7 +787,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubic3D_xpand", T(T(0.25))));
+		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubic3D_xpand", T(0.25)));
 		m_Params.push_back(ParamWithName<T>(&m_Style, prefix + "cubic3D_style"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Fill,        prefix + "cubic3D_fill"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Smooth,      prefix + "cubic3D_smooth"));
@@ -915,7 +915,7 @@ public:
 		   << "\t\t{\n"
 		   << "\t\t	exnze = cos(atan2(vIn.x, vIn.z));\n"
 		   << "\t\t	wynze = sin(atan2(vIn.y, vIn.z));\n"
-		   << "\t\t	znxy = (exnze + wynze) * T(0.5);\n"
+		   << "\t\t	znxy = (exnze + wynze) * (real_t)(0.5);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
@@ -1005,7 +1005,7 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubicLattice_3D_xpand", T(T(0.2))));//Original used a prefix of cubic3D_, which is incompatible with Ember's design.
+		m_Params.push_back(ParamWithName<T>(&m_Xpand, prefix + "cubicLattice_3D_xpand", T(0.2)));//Original used a prefix of cubic3D_, which is incompatible with Ember's design.
 		m_Params.push_back(ParamWithName<T>(&m_Style, prefix + "cubicLattice_3D_style", 1, INTEGER, 1, 2));
 		m_Params.push_back(ParamWithName<T>(true, &m_Fill, prefix + "cubicLattice_3D_fill"));//Precalc.
 	}
@@ -1045,8 +1045,8 @@ public:
 		intmax_t varIndex = IndexInXform();
 
 		ss << "\t{\n"
-		   << "\t\treal_t expx = exp(vIn.x) * T(0.5);\n"
-		   << "\t\treal_t expnx = T(0.25) / expx;\n"
+		   << "\t\treal_t expx = exp(vIn.x) * (real_t)(0.5);\n"
+		   << "\t\treal_t expnx = (real_t)(0.25) / expx;\n"
 		   << "\t\treal_t boot = vIn.z == 0 ? precalcAtanyx : vIn.z;\n"
 		   << "\t\treal_t tmp = xform->m_VariationWeights[" << varIndex << "] / (expx + expnx - (cos(vIn.y) * cos(boot)));\n"
 		   << "\n"
@@ -1117,8 +1117,8 @@ public:
 		   << "\t\treal_t cv = cos(vIn.y);\n"
 		   << "\t\treal_t cucv = cu * cv;\n"
 		   << "\t\treal_t sucv = su * cv;\n"
-		   << "\t\treal_t x = pow(fabs(cucv), " << xpow << ") + (cucv * " << xpow << ") + (T(0.25) * atOmegaX);\n"
-		   << "\t\treal_t y = pow(fabs(sucv), " << ypow << ") + (sucv * " << ypow << ") + (T(0.25) * atOmegaY);\n"
+		   << "\t\treal_t x = pow(fabs(cucv), " << xpow << ") + (cucv * " << xpow << ") + ((real_t)(0.25) * atOmegaX);\n"
+		   << "\t\treal_t y = pow(fabs(sucv), " << ypow << ") + (sucv * " << ypow << ") + ((real_t)(0.25) * atOmegaY);\n"
 		   << "\t\treal_t z = pow(fabs(sv), "   << zpow << ") + sv * "    << zpow << ";\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * x;\n"
@@ -1373,13 +1373,13 @@ public:
 		   << "\n"
 		   << "\t\t	vOut.x = r * vIn.x;\n"
 		   << "\t\t	vOut.y = r * vIn.y;\n"
-		   << "\t\t	vOut.z = r * efTez * T(0.5);\n"
+		   << "\t\t	vOut.z = r * efTez * (real_t)(0.5);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
 		   << "\t\t	vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t	vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t	vOut.z = xform->m_VariationWeights[" << varIndex << "] * efTez * T(0.5);\n"
+		   << "\t\t	vOut.z = xform->m_VariationWeights[" << varIndex << "] * efTez * (real_t)(0.5);\n"
 		   << "\t\t}\n"
 		   << "\t}\n";
 
@@ -1442,7 +1442,7 @@ public:
 		string tilt  = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t t = precalcSumSquares * T(0.25) + 1;\n"
+		   << "\t\treal_t t = precalcSumSquares * (real_t)(0.25) + 1;\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] / t;\n"
 		   << "\n"
 		   << "\t\tvOut.x = vIn.x * r * " << x << ";\n"
@@ -1510,7 +1510,7 @@ public:
 		string scale = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t avgxy = (vIn.x + vIn.y) * T(0.5);\n"
+		   << "\t\treal_t avgxy = (vIn.x + vIn.y) * (real_t)(0.5);\n"
 		   << "\n"
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + " << scale << " * sin(vIn.y * " << freq << "));\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + " << scale << " * sin(vIn.x * " << freq << "));\n"
@@ -1571,7 +1571,7 @@ public:
 		string thickness = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + T(0.5));\n"
+		   << "\t\tint sl = (int)(MwcNext01(mwc) * " << slices << " + (real_t)(0.5));\n"
 		   << "\t\treal_t a = " << rotation << " + M_2PI * (sl + MwcNext01(mwc) * " << thickness << ") / " << slices << ";\n"
 		   << "\t\treal_t r = xform->m_VariationWeights[" << varIndex << "] * MwcNext01(mwc);\n"
 		   << "\n"
@@ -1597,8 +1597,8 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Slices,    prefix + "pie3D_slices", 6, INTEGER_NONZERO, 1));
-		m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie3D_rotation", T(T(0.5)), REAL_CYCLIC, 0, M_2PI));
-		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie3D_thickness", T(T(0.5)), REAL, 0, 1));
+		m_Params.push_back(ParamWithName<T>(&m_Rotation,  prefix + "pie3D_rotation", T(0.5), REAL_CYCLIC, 0, M_2PI));
+		m_Params.push_back(ParamWithName<T>(&m_Thickness, prefix + "pie3D_thickness", T(0.5), REAL, 0, 1));
 	}
 
 private:
@@ -1698,9 +1698,9 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_3D_x", T(T(0.1))));
-		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_3D_y", T(T(0.1))));
-		m_Params.push_back(ParamWithName<T>(&m_Z, prefix + "popcorn2_3D_z", T(T(0.1))));
+		m_Params.push_back(ParamWithName<T>(&m_X, prefix + "popcorn2_3D_x", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_Y, prefix + "popcorn2_3D_y", T(0.1)));
+		m_Params.push_back(ParamWithName<T>(&m_Z, prefix + "popcorn2_3D_z", T(0.1)));
 		m_Params.push_back(ParamWithName<T>(&m_C, prefix + "popcorn2_3D_c", 3));
 		m_Params.push_back(ParamWithName<T>(true, &m_SinTanC,    prefix + "popcorn2_3D_sintanc"));
 		m_Params.push_back(ParamWithName<T>(true, &m_HalfWeight, prefix + "popcorn2_3D_half_weight"));
@@ -1863,8 +1863,8 @@ public:
 		   << "\t\tconst real_t xrng = vIn.x / " << xdist << ";\n"
 		   << "\t\tconst real_t yrng = vIn.y / " << ydist << ";\n"
 		   << "\n"
-		   << "\t\tvOut.x = " << xw << " * ((xrng - (int)xrng) * " << xwidth << " + (int)xrng + (T(0.5) - xpos) * " << onemx << ");\n"
-		   << "\t\tvOut.y = " << yw << " * ((yrng - (int)yrng) * " << ywidth << " + (int)yrng + (T(0.5) - ypos) * " << onemy << ");\n"
+		   << "\t\tvOut.x = " << xw << " * ((xrng - (int)xrng) * " << xwidth << " + (int)xrng + ((real_t)(0.5) - xpos) * " << onemx << ");\n"
+		   << "\t\tvOut.y = " << yw << " * ((yrng - (int)yrng) * " << ywidth << " + (int)yrng + ((real_t)(0.5) - ypos) * " << onemy << ");\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
 		   << "\t}\n";
 
@@ -1886,9 +1886,9 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_XDistance, prefix + "shredlin_xdistance", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_XWidth,    prefix + "shredlin_xwidth", T(T(0.5)), REAL, -1, 1));
+		m_Params.push_back(ParamWithName<T>(&m_XWidth,    prefix + "shredlin_xwidth", T(0.5), REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(&m_YDistance, prefix + "shredlin_ydistance", 1, REAL_NONZERO));
-		m_Params.push_back(ParamWithName<T>(&m_YWidth,    prefix + "shredlin_ywidth", T(T(0.5)), REAL, -1, 1));
+		m_Params.push_back(ParamWithName<T>(&m_YWidth,    prefix + "shredlin_ywidth", T(0.5), REAL, -1, 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Xw,  prefix + "shredlin_xw"));
 		m_Params.push_back(ParamWithName<T>(true, &m_Yw,  prefix + "shredlin_yw"));
 		m_Params.push_back(ParamWithName<T>(true, &m_1mX, prefix + "shredlin_1mx"));
@@ -1983,7 +1983,7 @@ public:
 		string py = "parVars[" + ToUpper(m_Params[i++].Name()) + index;
 
 		ss << "\t{\n"
-		   << "\t\treal_t b = xform->m_VariationWeights[" << varIndex << "] / (precalcSumSquares * T(0.25) + 1);\n"
+		   << "\t\treal_t b = xform->m_VariationWeights[" << varIndex << "] / (precalcSumSquares * (real_t)(0.25) + 1);\n"
 		   << "\t\treal_t roundX = rint(vIn.x);\n"
 		   << "\t\treal_t roundY = rint(vIn.y);\n"
 		   << "\t\treal_t offsetX = vIn.x - roundX;\n"
@@ -1992,10 +1992,10 @@ public:
 		   << "\t\tvOut.x = vIn.x * b;\n"
 		   << "\t\tvOut.y = vIn.y * b;\n"
 		   << "\n"
-		   << "\t\tif (MwcNext01(mwc) >= T(0.75))\n"
+		   << "\t\tif (MwcNext01(mwc) >= (real_t)(0.75))\n"
 		   << "\t\t{\n"
-		   << "\t\t	vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX);\n"
-		   << "\t\t	vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY);\n"
+		   << "\t\t	vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX);\n"
+		   << "\t\t	vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY);\n"
 		   << "\t\t}\n"
 		   << "\t\telse\n"
 		   << "\t\t{\n"
@@ -2003,26 +2003,26 @@ public:
 		   << "\t\t	{\n"
 		   << "\t\t		if (offsetX >= 0)\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + " << x << ");\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + " << y << " * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX + " << x << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY + " << y << " * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - " << y << ");\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - " << y << " * offsetY / offsetX);\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX - " << y << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY - " << y << " * offsetY / offsetX);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
 		   << "\t\t	{\n"
 		   << "\t\t		if (offsetY >= 0)\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY + " << y << ");\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX + offsetX / offsetY * " << y << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY + " << y << ");\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX + offsetX / offsetY * " << y << ");\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
-		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * T(0.5) + roundY - " << y << ");\n"
-		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * T(0.5) + roundX - offsetX / offsetY * " << x << ");\n"
+		   << "\t\t			vOut.y += xform->m_VariationWeights[" << varIndex << "] * (offsetY * (real_t)(0.5) + roundY - " << y << ");\n"
+		   << "\t\t			vOut.x += xform->m_VariationWeights[" << varIndex << "] * (offsetX * (real_t)(0.5) + roundX - offsetX / offsetY * " << x << ");\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
@@ -2041,8 +2041,8 @@ protected:
 		string prefix = Prefix();
 
 		m_Params.clear();
-		m_Params.push_back(ParamWithName<T>(&m_X,  prefix + "SplitBrdr_x",  T(T(0.25))));//Original used a prefix of splitb_, which is incompatible with Ember's design.
-		m_Params.push_back(ParamWithName<T>(&m_Y,  prefix + "SplitBrdr_y",  T(T(0.25))));
+		m_Params.push_back(ParamWithName<T>(&m_X,  prefix + "SplitBrdr_x",  T(0.25)));//Original used a prefix of splitb_, which is incompatible with Ember's design.
+		m_Params.push_back(ParamWithName<T>(&m_Y,  prefix + "SplitBrdr_y",  T(0.25)));
 		m_Params.push_back(ParamWithName<T>(&m_Px, prefix + "SplitBrdr_px"));
 		m_Params.push_back(ParamWithName<T>(&m_Py, prefix + "SplitBrdr_py"));
 	}
@@ -2181,8 +2181,8 @@ public:
 		   << "\t\tconst real_t ay = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t az = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t r = sqrt(Sqr(vIn.x - " << x0 << ") + Sqr(vIn.y - " << y0 << ") + Sqr(vIn.z - " << z0 << "));\n"
-		   << "\t\tconst real_t rc = ((" << invert << " != 0 ? max(1 - r, T(0.0)) : max(r, T(0.0))) - " << minDist << ") * " << internalScatter << ";\n"
-		   << "\t\tconst real_t rs = max(rc, T(0.0));\n"
+		   << "\t\tconst real_t rc = ((" << invert << " != 0 ? max(1 - r, (real_t)(0.0)) : max(r, (real_t)(0.0))) - " << minDist << ") * " << internalScatter << ";\n"
+		   << "\t\tconst real_t rs = max(rc, (real_t)(0.0));\n"
 		   << "\n"
 		   << "\t\treal_t sigma, phi, rad, sigmas, sigmac, phis, phic;\n"
 		   << "\t\treal_t scale, denom;\n"
@@ -2209,7 +2209,7 @@ public:
 		   << "\t\t		vOut.z = xform->m_VariationWeights[" << varIndex << "] * (rad * sigmas);\n"
 		   << "\t\t		break;\n"
 		   << "\t\t	case 2:\n"
-		   << "\t\t		scale = Clamp(rs, 0, T(0.9)) + T(0.1);\n"
+		   << "\t\t		scale = Clamp(rs, 0, (real_t)(0.9)) + (real_t)(0.1);\n"
 		   << "\t\t		denom = 1 / scale;\n"
 		   << "\t\t		vOut.x = xform->m_VariationWeights[" << varIndex << "] * Lerp(vIn.x, floor(vIn.x * denom) + scale * ax, " << mulX << " * rs) + " << mulX << " * pow(ax, " << boxPow << ") * rs * denom;\n"
 		   << "\t\t		vOut.y = xform->m_VariationWeights[" << varIndex << "] * Lerp(vIn.y, floor(vIn.y * denom) + scale * ay, " << mulY << " * rs) + " << mulY << " * pow(ay, " << boxPow << ") * rs * denom;\n"
@@ -2233,7 +2233,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Scatter, prefix + "falloff_scatter", 1, REAL, EPS, TMAX));
-		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff_mindist", T(T(0.5)), REAL, 0, TMAX));
+		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff_mindist", T(0.5), REAL, 0, TMAX));
 		m_Params.push_back(ParamWithName<T>(&m_MulX,    prefix + "falloff_mul_x", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulY,    prefix + "falloff_mul_y", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulZ,    prefix + "falloff_mul_z", 0, REAL, 0, 1));
@@ -2361,8 +2361,8 @@ public:
 		   << "\t\tconst real_t randz = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t randc = MwcNext0505(mwc);\n"
 		   << "\t\tconst real_t distA = sqrt(Sqr(vIn.x - " << x0 << ") + Sqr(vIn.y - " << y0 << ") + Sqr(vIn.z - " << z0 << "));\n"
-		   << "\t\tconst real_t distB = " << invert << " != 0 ? max(1 - distA, T(0.0)) : max(distA, T(0.0));\n"
-		   << "\t\tconst real_t dist = max((distB - " << minDist << ") * " << rMax<< ", T(0.0));\n"
+		   << "\t\tconst real_t distB = " << invert << " != 0 ? max(1 - distA, (real_t)(0.0)) : max(distA, (real_t)(0.0));\n"
+		   << "\t\tconst real_t dist = max((distB - " << minDist << ") * " << rMax<< ", (real_t)(0.0));\n"
 		   << "\n"
 		   << "\t\tswitch ((int)" << type << ")\n"
 		   << "\t\t{\n"
@@ -2370,7 +2370,7 @@ public:
 		   << "\t\t	   vOut.x = vIn.x + " << mulX << " * randx * dist;\n"
 		   << "\t\t	   vOut.y = vIn.y + " << mulY << " * randy * dist;\n"
 		   << "\t\t	   vOut.z = vIn.z + " << mulZ << " * randz * dist;\n"
-		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
+		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, (real_t)(1.0)));\n"
 		   << "\t\t	   break;\n"
 		   << "\t\t   case 1:\n"
 		   << "\t\t	   if (vIn.x == 0 && vIn.y == 0 && vIn.z == 0)\n"
@@ -2393,7 +2393,7 @@ public:
 		   << "\t\t		   vOut.x = r * sigmac * phic;\n"
 		   << "\t\t		   vOut.y = r * sigmac * phis;\n"
 		   << "\t\t		   vOut.z = r * sigmas;\n"
-		   << "\t\t		   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
+		   << "\t\t		   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, (real_t)(1.0)));\n"
 		   << "\t\t	   }\n"
 		   << "\t\t	   break;\n"
 		   << "\t\t   case 2:\n"
@@ -2409,7 +2409,7 @@ public:
 		   << "\t\t	   vOut.x = vIn.x + " << mulX << " * rad * sigmac * phic;\n"
 		   << "\t\t	   vOut.y = vIn.y + " << mulY << " * rad * sigmac * phis;\n"
 		   << "\t\t	   vOut.z = vIn.z + " << mulZ << " * rad * sigmas;\n"
-		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
+		   << "\t\t	   outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, (real_t)(1.0)));\n"
 		   << "\t\t	   break;\n"
 		   << "\t\t	  }\n"
 		   << "\t\t}\n"
@@ -2430,7 +2430,7 @@ protected:
 
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Scatter, prefix + "falloff2_scatter", 1, REAL, EPS, TMAX));
-		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff2_mindist", T(T(0.5)), REAL, 0, TMAX));
+		m_Params.push_back(ParamWithName<T>(&m_MinDist, prefix + "falloff2_mindist", T(0.5), REAL, 0, TMAX));
 		m_Params.push_back(ParamWithName<T>(&m_MulX,    prefix + "falloff2_mul_x", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulY,    prefix + "falloff2_mul_y", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulZ,    prefix + "falloff2_mul_z", 0, REAL, 0, 1));
@@ -2584,7 +2584,7 @@ public:
 		    << "\t\t		break;\n"
 		    << "\t\t}\n"
 		    << "\n"
-		    << "\t\tconst real_t dist = max(((" << invertDist << " != 0 ? max(1 - radius, T(0.0)) : max(radius, T(0.0))) - " << minDist << ") * " << rMax << ", T(0.0));\n"
+		    << "\t\tconst real_t dist = max(((" << invertDist << " != 0 ? max(1 - radius, (real_t)(0.0)) : max(radius, (real_t)(0.0))) - " << minDist << ") * " << rMax << ", (real_t)(0.0));\n"
 		    << "\n"
 		    << "\t\tswitch ((int)" << blurType << ")\n"
 		    << "\t\t{\n"
@@ -2601,7 +2601,7 @@ public:
 		    << "\t\t		vOut.x = vIn.x + " << mulX << " * rad * sigmac * phic;\n"
 		    << "\t\t		vOut.y = vIn.y + " << mulY << " * rad * sigmac * phis;\n"
 		    << "\t\t		vOut.z = vIn.z + " << mulZ << " * rad * sigmas;\n"
-		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
+		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, (real_t)(1.0)));\n"
 		    << "\t\t	}\n"
 		    << "\t\t	break;\n"
 		    << "\t\tcase 1:\n"
@@ -2625,7 +2625,7 @@ public:
 		    << "\t\t		vOut.x = r * sigmac * phic;\n"
 		    << "\t\t		vOut.y = r * sigmac * phis;\n"
 		    << "\t\t		vOut.z = r * sigmas;\n"
-		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, T(1.0)));\n"
+		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + " << mulC << " * randc * dist, (real_t)(1.0)));\n"
 		    << "\t\t	}\n"
 		    << "\t\t	break;\n"
 		    << "\t\tcase 2:\n"
@@ -2635,7 +2635,7 @@ public:
 		    << "\t\t		vOut.x = vIn.x + LogMap(" << mulX << ") * LogScale(randx) * coeff,\n"
 		    << "\t\t		vOut.y = vIn.y + LogMap(" << mulY << ") * LogScale(randy) * coeff,\n"
 		    << "\t\t		vOut.z = vIn.z + LogMap(" << mulZ << ") * LogScale(randz) * coeff,\n"
-		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + LogMap(" << mulC << ") * LogScale(randc) * coeff, T(1.0)));\n"
+		    << "\t\t		outPoint->m_ColorX = fabs(fmod(outPoint->m_ColorX + LogMap(" << mulC << ") * LogScale(randc) * coeff, (real_t)(1.0)));\n"
 		    << "\t\t	}\n"
 		    << "\t\t	break;\n"
 		    << "\t\t}\n"
@@ -2658,7 +2658,7 @@ protected:
 		m_Params.push_back(ParamWithName<T>(&m_BlurType,       prefix + "falloff3_blur_type", 0, INTEGER, 0, 3));
 		m_Params.push_back(ParamWithName<T>(&m_BlurShape,      prefix + "falloff3_blur_shape", 0, INTEGER, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_BlurStrength,   prefix + "falloff3_blur_strength", 1, REAL, EPS, TMAX));
-		m_Params.push_back(ParamWithName<T>(&m_MinDistance,    prefix + "falloff3_min_distance", T(T(0.5)), REAL, 0, TMAX));
+		m_Params.push_back(ParamWithName<T>(&m_MinDistance,    prefix + "falloff3_min_distance", T(0.5), REAL, 0, TMAX));
 		m_Params.push_back(ParamWithName<T>(&m_InvertDistance, prefix + "falloff3_invert_distance", 0, INTEGER, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulX,           prefix + "falloff3_mul_x", 1, REAL, 0, 1));
 		m_Params.push_back(ParamWithName<T>(&m_MulY,           prefix + "falloff3_mul_y", 1, REAL, 0, 1));
@@ -3053,7 +3053,7 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Power,  prefix + "xtrb_power", 2, INTEGER_NONZERO));
 		m_Params.push_back(ParamWithName<T>(&m_Radius, prefix + "xtrb_radius", 1));
-		m_Params.push_back(ParamWithName<T>(&m_Width,  prefix + "xtrb_width", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_Width,  prefix + "xtrb_width", T(0.5)));
 		m_Params.push_back(ParamWithName<T>(&m_Dist,   prefix + "xtrb_dist", 1));
 		m_Params.push_back(ParamWithName<T>(&m_A,      prefix + "xtrb_a", 1));
 		m_Params.push_back(ParamWithName<T>(&m_B,      prefix + "xtrb_b", 1));

--- a/Source/Ember/VariationsDC.h
+++ b/Source/Ember/VariationsDC.h
@@ -59,7 +59,7 @@ public:
 		   << "\t\treal_t tempX = vOut.x + outPoint->m_X;\n"
 		   << "\t\treal_t tempY = vOut.y + outPoint->m_Y;\n"
 		   << "\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(" << bdcs << " * (Sqr(tempX + " << centerX << ") + Sqr(tempY + " << centerY << "))), T(1.0));\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(" << bdcs << " * (Sqr(tempX + " << centerX << ") + Sqr(tempY + " << centerY << "))), (real_t)(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -138,7 +138,7 @@ public:
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (xform->m_A * x + xform->m_B * y + xform->m_E);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (xform->m_C * x + xform->m_D * y + xform->m_F);\n"
 		   << "\t\tvOut.z = " << ((m_VarType == VARTYPE_REG) ? "0" : "vIn.z") << ";\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(outPoint->m_ColorX * T(0.5) * (1 + h) + x0_xor_y0 * (1 - h) * T(0.5)), T(1.0));\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(outPoint->m_ColorX * (real_t)(0.5) * (1 + h) + x0_xor_y0 * (1 - h) * (real_t)(0.5)), (real_t)(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -416,7 +416,7 @@ public:
 		   << "\t\treal_t tempX = vOut.x + outPoint->m_X;\n"
 		   << "\t\treal_t tempY = vOut.y + outPoint->m_Y;\n"
 		   << "\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(T(0.5) * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + T(1.0))), T(1.0));\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs((real_t)(0.5) * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + (real_t)(1.0))), (real_t)(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -437,9 +437,9 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Offset, prefix + "dc_cylinder_offset"));//Params.
 		m_Params.push_back(ParamWithName<T>(&m_Angle,  prefix + "dc_cylinder_angle"));//Original used a prefix of dc_cyl_, which is incompatible with Ember's design.
-		m_Params.push_back(ParamWithName<T>(&m_Scale,  prefix + "dc_cylinder_scale", T(T(0.5))));
-		m_Params.push_back(ParamWithName<T>(&m_X,      prefix + "dc_cylinder_x", T(T(0.125))));//Original used a prefix of cyl_, which is incompatible with Ember's design.
-		m_Params.push_back(ParamWithName<T>(&m_Y,      prefix + "dc_cylinder_y", T(T(0.125))));
+		m_Params.push_back(ParamWithName<T>(&m_Scale,  prefix + "dc_cylinder_scale", T(0.5)));
+		m_Params.push_back(ParamWithName<T>(&m_X,      prefix + "dc_cylinder_x", T(0.125)));//Original used a prefix of cyl_, which is incompatible with Ember's design.
+		m_Params.push_back(ParamWithName<T>(&m_Y,      prefix + "dc_cylinder_y", T(0.125)));
 		m_Params.push_back(ParamWithName<T>(&m_Blur,   prefix + "dc_cylinder_blur", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Sina, prefix + "dc_cylinder_sina"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Cosa, prefix + "dc_cylinder_cosa"));
@@ -566,13 +566,13 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += T(0.25);\n"
+		   << "\t\t			c += (real_t)(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + 1);\n"
-		   << "\t\t			c += T(0.75);\n"
+		   << "\t\t			c += (real_t)(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
@@ -581,13 +581,13 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += T(0.25);\n"
+		   << "\t\t			c += (real_t)(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y - 1);\n"
-		   << "\t\t			c += T(0.75);\n"
+		   << "\t\t			c += (real_t)(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
@@ -599,13 +599,13 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x - 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += T(0.25);\n"
+		   << "\t\t			c += (real_t)(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + 1);\n"
-		   << "\t\t			c += T(0.75);\n"
+		   << "\t\t			c += (real_t)(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
@@ -614,19 +614,19 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x - 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += T(0.25);\n"
+		   << "\t\t			c += (real_t)(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y - 1);\n"
-		   << "\t\t			c += T(0.75);\n"
+		   << "\t\t			c += (real_t)(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
 		   << "\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
-		   << "\t\toutPoint->m_ColorX = fmod(c, T(1.0));\n"
+		   << "\t\toutPoint->m_ColorX = fmod(c, (real_t)(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -683,7 +683,7 @@ public:
 		   << "\t\treal_t tempX = vOut.x + outPoint->m_X;\n"
 		   << "\t\treal_t tempY = vOut.y + outPoint->m_Y;\n"
 		   << "\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(T(0.5) * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + T(1.0))), T(1.0));\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs((real_t)(0.5) * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + (real_t)(1.0))), (real_t)(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -907,7 +907,7 @@ public:
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (ox + u * xx + v * yx);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (oy + u * xy + v * yy);\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(u + v), T(1.0));\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(u + v), (real_t)(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();

--- a/Source/Ember/VariationsDC.h
+++ b/Source/Ember/VariationsDC.h
@@ -59,7 +59,7 @@ public:
 		   << "\t\treal_t tempX = vOut.x + outPoint->m_X;\n"
 		   << "\t\treal_t tempY = vOut.y + outPoint->m_Y;\n"
 		   << "\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(" << bdcs << " * (Sqr(tempX + " << centerX << ") + Sqr(tempY + " << centerY << "))), 1.0);\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(" << bdcs << " * (Sqr(tempX + " << centerX << ") + Sqr(tempY + " << centerY << "))), T(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -138,7 +138,7 @@ public:
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (xform->m_A * x + xform->m_B * y + xform->m_E);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (xform->m_C * x + xform->m_D * y + xform->m_F);\n"
 		   << "\t\tvOut.z = " << ((m_VarType == VARTYPE_REG) ? "0" : "vIn.z") << ";\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(outPoint->m_ColorX * 0.5 * (1 + h) + x0_xor_y0 * (1 - h) * 0.5), 1.0);\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(outPoint->m_ColorX * T(0.5) * (1 + h) + x0_xor_y0 * (1 - h) * T(0.5)), T(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -416,7 +416,7 @@ public:
 		   << "\t\treal_t tempX = vOut.x + outPoint->m_X;\n"
 		   << "\t\treal_t tempY = vOut.y + outPoint->m_Y;\n"
 		   << "\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(0.5 * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + 1.0)), 1.0);\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(T(0.5) * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + T(1.0))), T(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -437,9 +437,9 @@ protected:
 		m_Params.clear();
 		m_Params.push_back(ParamWithName<T>(&m_Offset, prefix + "dc_cylinder_offset"));//Params.
 		m_Params.push_back(ParamWithName<T>(&m_Angle,  prefix + "dc_cylinder_angle"));//Original used a prefix of dc_cyl_, which is incompatible with Ember's design.
-		m_Params.push_back(ParamWithName<T>(&m_Scale,  prefix + "dc_cylinder_scale", T(0.5)));
-		m_Params.push_back(ParamWithName<T>(&m_X,      prefix + "dc_cylinder_x", T(0.125)));//Original used a prefix of cyl_, which is incompatible with Ember's design.
-		m_Params.push_back(ParamWithName<T>(&m_Y,      prefix + "dc_cylinder_y", T(0.125)));
+		m_Params.push_back(ParamWithName<T>(&m_Scale,  prefix + "dc_cylinder_scale", T(T(0.5))));
+		m_Params.push_back(ParamWithName<T>(&m_X,      prefix + "dc_cylinder_x", T(T(0.125))));//Original used a prefix of cyl_, which is incompatible with Ember's design.
+		m_Params.push_back(ParamWithName<T>(&m_Y,      prefix + "dc_cylinder_y", T(T(0.125))));
 		m_Params.push_back(ParamWithName<T>(&m_Blur,   prefix + "dc_cylinder_blur", 1));
 		m_Params.push_back(ParamWithName<T>(true, &m_Sina, prefix + "dc_cylinder_sina"));//Precalc.
 		m_Params.push_back(ParamWithName<T>(true, &m_Cosa, prefix + "dc_cylinder_cosa"));
@@ -566,13 +566,13 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += 0.25;\n"
+		   << "\t\t			c += T(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + 1);\n"
-		   << "\t\t			c += 0.75;\n"
+		   << "\t\t			c += T(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
@@ -581,13 +581,13 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x + 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += 0.25;\n"
+		   << "\t\t			c += T(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y - 1);\n"
-		   << "\t\t			c += 0.75;\n"
+		   << "\t\t			c += T(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
@@ -599,13 +599,13 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x - 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += 0.25;\n"
+		   << "\t\t			c += T(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y + 1);\n"
-		   << "\t\t			c += 0.75;\n"
+		   << "\t\t			c += T(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t	else\n"
@@ -614,19 +614,19 @@ public:
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * (vIn.x - 1);\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * vIn.y;\n"
-		   << "\t\t			c += 0.25;\n"
+		   << "\t\t			c += T(0.25);\n"
 		   << "\t\t		}\n"
 		   << "\t\t		else\n"
 		   << "\t\t		{\n"
 		   << "\t\t			vOut.x = xform->m_VariationWeights[" << varIndex << "] * vIn.x;\n"
 		   << "\t\t			vOut.y = xform->m_VariationWeights[" << varIndex << "] * (vIn.y - 1);\n"
-		   << "\t\t			c += 0.75;\n"
+		   << "\t\t			c += T(0.75);\n"
 		   << "\t\t		}\n"
 		   << "\t\t	}\n"
 		   << "\t\t}\n"
 		   << "\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
-		   << "\t\toutPoint->m_ColorX = fmod(c, 1.0);\n"
+		   << "\t\toutPoint->m_ColorX = fmod(c, T(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -683,7 +683,7 @@ public:
 		   << "\t\treal_t tempX = vOut.x + outPoint->m_X;\n"
 		   << "\t\treal_t tempY = vOut.y + outPoint->m_Y;\n"
 		   << "\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(0.5 * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + 1.0)), 1.0);\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(T(0.5) * (" << ldcs << " * ((" << cosa << " * tempX + " << sina << " * tempY + " << offset << ")) + T(1.0))), T(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();
@@ -907,7 +907,7 @@ public:
 		   << "\t\tvOut.x = xform->m_VariationWeights[" << varIndex << "] * (ox + u * xx + v * yx);\n"
 		   << "\t\tvOut.y = xform->m_VariationWeights[" << varIndex << "] * (oy + u * xy + v * yy);\n"
 		   << "\t\tvOut.z = xform->m_VariationWeights[" << varIndex << "] * vIn.z;\n"
-		   << "\t\toutPoint->m_ColorX = fmod(fabs(u + v), 1.0);\n"
+		   << "\t\toutPoint->m_ColorX = fmod(fabs(u + v), T(1.0));\n"
 		   << "\t}\n";
 
 		return ss.str();

--- a/Source/EmberCL/FinalAccumOpenCLKernelCreator.cpp
+++ b/Source/EmberCL/FinalAccumOpenCLKernelCreator.cpp
@@ -377,7 +377,7 @@ string FinalAccumOpenCLKernelCreator<T>::CreateGammaCorrectionFunctionString(boo
 
 	os <<
 	"\n"
-	"			correctedChannels[rgbi] = (" << dataType << ")clamp(a, 0.0f, 255.0f);\n"
+	"			correctedChannels[rgbi] = (" << dataType << ")clamp(a, T(0.0), T(255.0));\n"
 	"		}\n"
 	"\n";
 

--- a/Source/EmberCL/FinalAccumOpenCLKernelCreator.cpp
+++ b/Source/EmberCL/FinalAccumOpenCLKernelCreator.cpp
@@ -377,7 +377,7 @@ string FinalAccumOpenCLKernelCreator<T>::CreateGammaCorrectionFunctionString(boo
 
 	os <<
 	"\n"
-	"			correctedChannels[rgbi] = (" << dataType << ")clamp(a, T(0.0), T(255.0));\n"
+	"			correctedChannels[rgbi] = (" << dataType << ")clamp(a, (real_t)0.0, (real_t)255.0);\n"
 	"		}\n"
 	"\n";
 

--- a/Source/EmberCL/FinalAccumOpenCLKernelCreator.cpp
+++ b/Source/EmberCL/FinalAccumOpenCLKernelCreator.cpp
@@ -377,7 +377,7 @@ string FinalAccumOpenCLKernelCreator<T>::CreateGammaCorrectionFunctionString(boo
 
 	os <<
 	"\n"
-	"			correctedChannels[rgbi] = (" << dataType << ")clamp(a, 0.0, 255.0);\n"
+	"			correctedChannels[rgbi] = (" << dataType << ")clamp(a, 0.0f, 255.0f);\n"
 	"		}\n"
 	"\n";
 

--- a/Source/EmberCL/OpenCLWrapper.cpp
+++ b/Source/EmberCL/OpenCLWrapper.cpp
@@ -1221,10 +1221,13 @@ bool OpenCLWrapper::CreateSPK(const string& name, const string& program, const s
 {
 	if (m_Init)
 	{
+		std::string precisionDef(doublePrecision ? "#define T(v) (double)(v)\n" : "#define T(v) (float)(v)\n");
+		std::string p(precisionDef + program);
+
 		cl_int err;
 
 		spk.m_Name = name;
-		spk.m_Source = cl::Program::Sources(1, std::make_pair(program.c_str(), program.length() + 1));
+		spk.m_Source = cl::Program::Sources(1, std::make_pair(p.c_str(), p.length() + 1));
 		spk.m_Program = cl::Program(m_Context, spk.m_Source);
 
 		if (doublePrecision)

--- a/Source/EmberCL/OpenCLWrapper.cpp
+++ b/Source/EmberCL/OpenCLWrapper.cpp
@@ -1246,10 +1246,10 @@ bool OpenCLWrapper::CreateSPK(const string& name, const string& program, const s
 
 			if (CheckCL(err, "cl::Kernel()"))
 				return true;//Everything is ok.
-    } else {
-      for (std::vector<cl::Device>::iterator i = m_DeviceVec.begin(); i != m_DeviceVec.end(); ++ i )
-        m_programBuildErrors.push_back(spk.m_Program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(*i));
-    }
+		} else {
+			for (std::vector<cl::Device>::iterator i = m_DeviceVec.begin(); i != m_DeviceVec.end(); ++ i )
+				m_programBuildErrors.push_back(spk.m_Program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(*i));
+		}
 	}
 
 	return false;

--- a/Source/EmberCL/OpenCLWrapper.cpp
+++ b/Source/EmberCL/OpenCLWrapper.cpp
@@ -1130,6 +1130,7 @@ uint OpenCLWrapper::DeviceIndex() const { return m_DeviceIndex; }
 size_t OpenCLWrapper::GlobalMemSize() const { return GetInfo<cl_ulong>(PlatformIndex(), DeviceIndex(), CL_DEVICE_GLOBAL_MEM_SIZE); }
 uint OpenCLWrapper::LocalMemSize() const { return m_LocalMemSize; }
 size_t OpenCLWrapper::MaxAllocSize() const { return GetInfo<cl_ulong>(PlatformIndex(), DeviceIndex(), CL_DEVICE_MAX_MEM_ALLOC_SIZE); }
+std::vector<std::string> OpenCLWrapper::ProgramBuildErrors() const { return m_programBuildErrors; }
 
 /// <summary>
 /// Makes the even grid dims.
@@ -1242,7 +1243,10 @@ bool OpenCLWrapper::CreateSPK(const string& name, const string& program, const s
 
 			if (CheckCL(err, "cl::Kernel()"))
 				return true;//Everything is ok.
-		}
+    } else {
+      for (std::vector<cl::Device>::iterator i = m_DeviceVec.begin(); i != m_DeviceVec.end(); ++ i )
+        m_programBuildErrors.push_back(spk.m_Program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(*i));
+    }
 	}
 
 	return false;

--- a/Source/EmberCL/OpenCLWrapper.cpp
+++ b/Source/EmberCL/OpenCLWrapper.cpp
@@ -1221,13 +1221,10 @@ bool OpenCLWrapper::CreateSPK(const string& name, const string& program, const s
 {
 	if (m_Init)
 	{
-		std::string precisionDef(doublePrecision ? "#define T(v) (double)(v)\n" : "#define T(v) (float)(v)\n");
-		std::string p(precisionDef + program);
-
 		cl_int err;
 
 		spk.m_Name = name;
-		spk.m_Source = cl::Program::Sources(1, std::make_pair(p.c_str(), p.length() + 1));
+		spk.m_Source = cl::Program::Sources(1, std::make_pair(program.c_str(), program.length() + 1));
 		spk.m_Program = cl::Program(m_Context, spk.m_Source);
 
 		if (doublePrecision)

--- a/Source/EmberCL/OpenCLWrapper.h
+++ b/Source/EmberCL/OpenCLWrapper.h
@@ -192,6 +192,7 @@ public:
 	uint LocalMemSize() const;
 	size_t GlobalMemSize() const;
 	size_t MaxAllocSize() const;
+  std::vector<std::string> ProgramBuildErrors() const;
 
 	static void MakeEvenGridDims(uint blockW, uint blockH, uint& gridW, uint& gridH);
 
@@ -217,5 +218,6 @@ private:
 	std::vector<NamedBuffer> m_Buffers;
 	std::vector<NamedImage2D> m_Images;
 	std::vector<NamedImage2DGL> m_GLImages;
+  std::vector<std::string> m_programBuildErrors;
 };
 }

--- a/Source/EmberCL/OpenCLWrapper.h
+++ b/Source/EmberCL/OpenCLWrapper.h
@@ -192,7 +192,7 @@ public:
 	uint LocalMemSize() const;
 	size_t GlobalMemSize() const;
 	size_t MaxAllocSize() const;
-  std::vector<std::string> ProgramBuildErrors() const;
+	std::vector<std::string> ProgramBuildErrors() const;
 
 	static void MakeEvenGridDims(uint blockW, uint blockH, uint& gridW, uint& gridH);
 
@@ -218,6 +218,6 @@ private:
 	std::vector<NamedBuffer> m_Buffers;
 	std::vector<NamedImage2D> m_Images;
 	std::vector<NamedImage2DGL> m_GLImages;
-  std::vector<std::string> m_programBuildErrors;
+	std::vector<std::string> m_programBuildErrors;
 };
 }

--- a/Source/EmberCL/RendererCL.cpp
+++ b/Source/EmberCL/RendererCL.cpp
@@ -742,8 +742,13 @@ bool RendererCL<T>::BuildIterProgramForEmber(bool doAccum)
 		m_LastBuiltEmber = m_Ember;
 	}
 	else
-	{
-		m_ErrorReport.push_back(string(loc) + "():\nBuilding the following program failed: \n" + m_IterKernel + "\n");
+  {
+    //m_ErrorReport.push_back(string(loc) + "():\nBuilding the following program failed: \n" + m_IterKernel + "\n");
+
+    std::vector<std::string> errors = m_Wrapper.ProgramBuildErrors();
+    m_ErrorReport.insert(m_ErrorReport.end(), errors.begin(), errors.end());
+    m_ErrorReport.push_back(loc);
+
 		return false;
 	}
 

--- a/Source/EmberCL/RendererCL.cpp
+++ b/Source/EmberCL/RendererCL.cpp
@@ -1276,7 +1276,11 @@ int RendererCL<T>::MakeAndGetFinalAccumProgram(T& alphaBase, T& alphaScale)
 		if (b)
 			kernelIndex = m_Wrapper.FindKernelIndex(finalAccumEntryPoint);//Try to find it again, it will be present if successfully built.
 		else
+    {
+      std::vector<std::string> errors = m_Wrapper.ProgramBuildErrors();
+      m_ErrorReport.insert(m_ErrorReport.end(), errors.begin(), errors.end());
 			m_ErrorReport.push_back(loc);
+    }
 	}
 
 	return kernelIndex;

--- a/Source/EmberCL/RendererCL.cpp
+++ b/Source/EmberCL/RendererCL.cpp
@@ -742,12 +742,12 @@ bool RendererCL<T>::BuildIterProgramForEmber(bool doAccum)
 		m_LastBuiltEmber = m_Ember;
 	}
 	else
-  {
-    //m_ErrorReport.push_back(string(loc) + "():\nBuilding the following program failed: \n" + m_IterKernel + "\n");
+	{
+		//m_ErrorReport.push_back(string(loc) + "():\nBuilding the following program failed: \n" + m_IterKernel + "\n");
 
-    std::vector<std::string> errors = m_Wrapper.ProgramBuildErrors();
-    m_ErrorReport.insert(m_ErrorReport.end(), errors.begin(), errors.end());
-    m_ErrorReport.push_back(loc);
+		std::vector<std::string> errors = m_Wrapper.ProgramBuildErrors();
+		m_ErrorReport.insert(m_ErrorReport.end(), errors.begin(), errors.end());
+		m_ErrorReport.push_back(loc);
 
 		return false;
 	}
@@ -1281,11 +1281,11 @@ int RendererCL<T>::MakeAndGetFinalAccumProgram(T& alphaBase, T& alphaScale)
 		if (b)
 			kernelIndex = m_Wrapper.FindKernelIndex(finalAccumEntryPoint);//Try to find it again, it will be present if successfully built.
 		else
-    {
-      std::vector<std::string> errors = m_Wrapper.ProgramBuildErrors();
-      m_ErrorReport.insert(m_ErrorReport.end(), errors.begin(), errors.end());
+		{
+			std::vector<std::string> errors = m_Wrapper.ProgramBuildErrors();
+			m_ErrorReport.insert(m_ErrorReport.end(), errors.begin(), errors.end());
 			m_ErrorReport.push_back(loc);
-    }
+		}
 	}
 
 	return kernelIndex;


### PR DESCRIPTION
Looks like Apple's opencl compiler is once again quite picky. All of the issues I was encountering stemmed from opencl compiler issues along the lines of
````
error: call to 'foo' is ambiguous
````

By explicitly specifying whether a floating-point literal is double or float, it tells the compiler which override to use when multiple precision definitions of a function are availble.

I also modified the opencl stuff to output program build errors to the info panel in Fractorium, so I could see what was going on. It's not copy-pastable but it shows where the problem is.