### PR TITLE
Ensure correct opencl device is populated on platform setting change

### DIFF
--- a/Source/Fractorium/OptionsDialog.cpp
+++ b/Source/Fractorium/OptionsDialog.cpp
@@ -134,6 +134,9 @@ void FractoriumOptionsDialog::OnPlatformComboCurrentIndexChanged(int index)
 
 	for (size_t i = 0; i < devices.size(); i++)
 		ui.DeviceCombo->addItem(QString::fromStdString(devices[i]));
+
+	if (ui.PlatformCombo->currentIndex() == m_Settings->PlatformIndex())
+		ui.DeviceCombo->setCurrentIndex(m_Settings->DeviceIndex());
 }
 
 /// <summary>


### PR DESCRIPTION
Currently my mac shows three unrelated devices for a single platform. (This seems incorrect, but it's what happens) -- The first is my CPU, the second is my Iris graphics, and third is my NVidia device.

When I open the options dialog for the first time, the wrong device is selected. It's correctly selected during initialisation, but OnPlatformComboCurrentIndexChanged is subsequently called which removes items from the combo and re-adds them. I've added a clause to say that if the platform being selected is the one defined by the program settings, reselect the device from the settings once the combo has been repopulated.

Seems to fix things this end.