### PR TITLE
Fix issues with image filenames in EmberAnimate with larger numbers of frames

### DIFF
--- a/Source/EmberAnimate/EmberAnimate.cpp
+++ b/Source/EmberAnimate/EmberAnimate.cpp
@@ -299,9 +299,9 @@ bool EmberAnimate(EmberOptions& opt)
 
 		if (opt.Out().empty())
 		{
-			os.str("");
-			os << inputPath << opt.Prefix() << setfill('0') << setw(5) << ftime << opt.Suffix() << "." << opt.Format();
-			filename = os.str();
+			ostringstream fnstream;
+			fnstream << inputPath << opt.Prefix() << setfill('0') << setw(5) << ftime << opt.Suffix() << "." << opt.Format();
+			filename = fnstream.str();
 		}
 
 		if (opt.WriteGenome())

--- a/Source/EmberAnimate/EmberAnimate.cpp
+++ b/Source/EmberAnimate/EmberAnimate.cpp
@@ -300,7 +300,7 @@ bool EmberAnimate(EmberOptions& opt)
 		if (opt.Out().empty())
 		{
 			ostringstream fnstream;
-			fnstream << inputPath << opt.Prefix() << setfill('0') << setw(5) << ftime << opt.Suffix() << "." << opt.Format();
+			fnstream << inputPath << opt.Prefix() << setfill('0') << setw(opt.FilenamePadding()) << ftime << opt.Suffix() << "." << opt.Format();
 			filename = fnstream.str();
 		}
 

--- a/Source/EmberCommon/EmberOptions.h
+++ b/Source/EmberCommon/EmberOptions.h
@@ -73,6 +73,7 @@ enum eOptionIDs
 	OPT_TIME,
 	OPT_DTIME,
 	OPT_NFRAMES,
+	OPT_FNPADDING,
 	OPT_SYMMETRY,
 	OPT_SHEEP_GEN,
 	OPT_SHEEP_ID,
@@ -349,6 +350,7 @@ public:
 		INITUINTOPTION(Frame,          Eou(OPT_ANIM_GENOME, OPT_FRAME,            _T("--frame"),                0,                    SO_REQ_SEP, "\t--frame=<val>            Synonym for \"time\".\n"));
 		INITUINTOPTION(Dtime,          Eou(OPT_USE_ANIMATE, OPT_DTIME,            _T("--dtime"),                1,                    SO_REQ_SEP, "\t--dtime=<val>            Time between frames [default: 1].\n"));
 		INITUINTOPTION(Frames,         Eou(OPT_USE_GENOME,  OPT_NFRAMES,          _T("--nframes"),              20,                   SO_REQ_SEP, "\t--nframes=<val>          Number of frames for each stage of the animation [default: 20].\n"));
+		INITUINTOPTION(FilenamePadding,Eou(OPT_USE_ANIMATE, OPT_FNPADDING,        _T("--filename_padding"),     5,                    SO_REQ_SEP, "\t--filename_padding=<val> Number of zeros to pad frame numbers with in output filename [default: 5].\n"));
 		INITUINTOPTION(Loops,          Eou(OPT_USE_GENOME,  OPT_LOOPS,            _T("--loops"),                1,                    SO_REQ_SEP, "\t--loops=<val>            Number of times to rotate each control point in sequence [default: 1].\n"));
 		INITUINTOPTION(Repeat,         Eou(OPT_USE_GENOME,  OPT_REPEAT,           _T("--repeat"),               1,                    SO_REQ_SEP, "\t--repeat=<val>           Number of new flames to create. Ignored if sequence, inter or rotate were specified [default: 1].\n"));
 		INITUINTOPTION(Tries,          Eou(OPT_USE_GENOME,  OPT_TRIES,            _T("--tries"),                10,                   SO_REQ_SEP, "\t--tries=<val>            Number times to try creating a flame that meets the specified constraints. Ignored if sequence, inter or rotate were specified [default: 10].\n"));
@@ -478,6 +480,7 @@ public:
 					PARSEUINTOPTION(OPT_TIME, Time);
 					PARSEUINTOPTION(OPT_DTIME, Dtime);
 					PARSEUINTOPTION(OPT_NFRAMES, Frames);
+					PARSEUINTOPTION(OPT_FNPADDING, FilenamePadding);
 					PARSEUINTOPTION(OPT_LOOPS, Loops);
 					PARSEUINTOPTION(OPT_REPEAT, Repeat);
 					PARSEUINTOPTION(OPT_TRIES, Tries);
@@ -693,6 +696,7 @@ public:
 	EmberOptionEntry<uint> Time;
 	EmberOptionEntry<uint> Dtime;
 	EmberOptionEntry<uint> Frames;
+	EmberOptionEntry<uint> FilenamePadding;
 	EmberOptionEntry<uint> Loops;
 	EmberOptionEntry<uint> Repeat;
 	EmberOptionEntry<uint> Tries;


### PR DESCRIPTION
Currently (on my locale) once the number of frames reaches 1000 or higher, filenames are output with a format of:
```` <prefix>1,000<suffix> ````
instead of:
```` <prefix>01000<suffix> ````

This is due to using a stringstream that has been imbued with a locale.

Also added a commandline parameter to EmberAnimate to control the number of zeros the output frame number is padded with to support very long animations.