### PR TITLE
Fix pedantic gcc error about missing template keyword

### DIFF
--- a/Source/EmberCL/RendererCL.cpp
+++ b/Source/EmberCL/RendererCL.cpp
@@ -1488,9 +1488,9 @@ void RendererCL<T>::FillSeeds()
 
 	for (auto& seed : m_Seeds)
 	{
-		seed.x = (uint)m_Rand[0].Frand<double>(start, start + delta);
+		seed.x = (uint)m_Rand[0].template Frand<double>(start, start + delta);
 		start += delta;
-		seed.y = (uint)m_Rand[0].Frand<double>(start, start + delta);
+		seed.y = (uint)m_Rand[0].template Frand<double>(start, start + delta);
 		start += delta;
 	}
 }


### PR DESCRIPTION
Fixes the following error in GCC:
````
../../../Source/EmberCL/RendererCL.cpp:1491:28: fatal error: use 'template' keyword to treat 'Frand' as a dependent template name
                seed.x = (uint)m_Rand[0].Frand<double>(start, start + delta);
                                         ^
                                         template 
````

It clearly knows what you were trying to do, but refuses to do it without the keyword.