### PR TITLE
Change hotkeys for copy/paste selected xforms

### DIFF
--- a/Source/Fractorium/Fractorium.ui
+++ b/Source/Fractorium/Fractorium.ui
@@ -6510,7 +6510,7 @@ SpinBox
     <string>Copy selected xforms to the clipboard</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Q</string>
+    <string>Ctrl+D</string>
    </property>
   </action>
   <action name="ActionPasteSelectedXforms">
@@ -6521,7 +6521,7 @@ SpinBox
     <string>Paste copied xforms into the current flame</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+W</string>
+    <string>Ctrl+S</string>
    </property>
   </action>
   <action name="ActionResetWorkspace">


### PR DESCRIPTION
Apple users will very much expect command-Q to exit the app.

I've set them here to D/S instead (one character up from C/X) but people may be used to them being on Q/W on Windows? In which case I might have to hunt around for a way to do this specifically on osx.

The downside of that would be inconsitency across platforms... Not sure which is best.

Issue gh2k/fractorium#5