### PR TITLE
Display char* excptions when Something Bad happens

### DIFF
--- a/Source/Fractorium/Main.cpp
+++ b/Source/Fractorium/Main.cpp
@@ -44,9 +44,18 @@ int main(int argc, char *argv[])
 	 "}" );
 #endif
 
-	Fractorium w;
-	w.show();
-	a.installEventFilter(&w);
-	return a.exec();
+	int rv = -1;
+
+	try
+	{
+		Fractorium w;
+		w.show();
+		a.installEventFilter(&w);
+		rv = a.exec();
+	} catch (const char *e) {
+		QMessageBox::critical(0, "Fatal Error", e);
+	}
+
+	return rv;
 }
 


### PR DESCRIPTION
When these are raised on osx (and Linux?) the program crashes with no error.

This displays the message in a fatal error box and then quits slightly more gracefully.