### PR TITLE
Force creation of native menu bar when main window is shown

### DIFF
--- a/Source/Fractorium/Fractorium.cpp
+++ b/Source/Fractorium/Fractorium.cpp
@@ -350,6 +350,19 @@ void Fractorium::resizeEvent(QResizeEvent* e)
 }
 
 /// <summary>
+/// Respond to a show event to ensure Qt updates the native menubar.
+/// On first create, Qt can fail to create the native menu bar properly,
+/// but telling it that this window has become the focus window forces
+/// it to refresh this.
+/// <param name="e">The event</param>
+void Fractorium::showEvent(QShowEvent *e)
+{
+	// tell Qt to refresh the native menubar from this widget
+	emit qGuiApp->focusWindowChanged(windowHandle());
+	QMainWindow::showEvent(e);
+}
+
+/// <summary>
 /// Stop rendering and block before exiting.
 /// Called on program exit.
 /// </summary>

--- a/Source/Fractorium/Fractorium.h
+++ b/Source/Fractorium/Fractorium.h
@@ -302,6 +302,7 @@ protected:
 	virtual void dragEnterEvent(QDragEnterEvent* e) override;
 	virtual void dragMoveEvent(QDragMoveEvent* e) override;
 	virtual void dropEvent(QDropEvent* e) override;
+	virtual void showEvent(QShowEvent *e) override;
 
 private:
 	void InitMenusUI();


### PR DESCRIPTION
Native menu bar recreation is hooked up to the focusWindowChanged signal in QGuiApplication. Emittng this when the window is shown ensures that Qt creates the menubar at the correct time.

Fixes gh2k/fractorium#1